### PR TITLE
extract isSaving property in callsMapping from localStorage to memory

### DIFF
--- a/packages/ringcentral-widgets/modules/CallLogSection/getCallLogSectionReducer.js
+++ b/packages/ringcentral-widgets/modules/CallLogSection/getCallLogSectionReducer.js
@@ -1,8 +1,32 @@
 import { combineReducers } from 'redux';
 import getModuleStatusReducer from 'ringcentral-integration/lib/getModuleStatusReducer';
 
+function getCallsSavingStatusReducer(types) {
+  return (state = {}, { type, identify }) => {
+    switch (type) {
+      case types.update:
+      case types.saving:
+        return {
+          ...state,
+          [identify]: true,
+        };
+      case types.saveSuccess:
+      case types.saveError:
+        return {
+          ...state,
+          [identify]: false,
+        };
+      case types.cleanUp:
+        return {};
+      default:
+        return state;
+    }
+  };
+}
+
 export default function getCallLogSectionReducer(types) {
   return combineReducers({
     status: getModuleStatusReducer(types),
+    callsSavingStatus: getCallsSavingStatusReducer(types),
   });
 }

--- a/packages/ringcentral-widgets/modules/CallLogSection/getStorageReducer.js
+++ b/packages/ringcentral-widgets/modules/CallLogSection/getStorageReducer.js
@@ -16,7 +16,6 @@ function getCallsMappingReducer(types) {
           ...state,
           [identify]: {
             ...state[identify],
-            isSaving: true
           },
         };
       case types.saveSuccess:
@@ -25,7 +24,6 @@ function getCallsMappingReducer(types) {
           [identify]: {
             ...state[identify],
             isEdited: false,
-            isSaving: false,
           },
         };
       case types.saveError:
@@ -34,7 +32,6 @@ function getCallsMappingReducer(types) {
           [identify]: {
             ...state[identify],
             isEdited: true,
-            isSaving: false,
           },
         };
       case types.cleanUp:

--- a/packages/ringcentral-widgets/modules/CallLogSection/index.js
+++ b/packages/ringcentral-widgets/modules/CallLogSection/index.js
@@ -1,3 +1,4 @@
+import * as R from 'ramda';
 import RcModule from 'ringcentral-integration/lib/RcModule';
 import { Module } from 'ringcentral-integration/lib/di';
 import ensureExist from 'ringcentral-integration/lib/ensureExist';
@@ -220,8 +221,25 @@ export default class CallLogSection extends RcModule {
     return this._storage.getItem(this._storageKey).callsList;
   }
 
-  get callsMapping() {
+  /**
+   * Merge isSaving properties from reducer to callsMapping
+   */
+  @getter
+  callsMapping = createSelector(
+    () => this._callsMapping,
+    () => this._callsSavingStatus,
+    R.mergeWith(R.flip(R.assoc('isSaving'))),
+  )
+
+  /**
+   * Private calls mapping relationship without isSaving properties
+   */
+  get _callsMapping() {
     return this._storage.getItem(this._storageKey).callsMapping;
+  }
+
+  get _callsSavingStatus() {
+    return this.state.callsSavingStatus;
   }
 
   get currentIdentify() {

--- a/packages/ringcentral-widgets/modules/CallLogSection/index.js
+++ b/packages/ringcentral-widgets/modules/CallLogSection/index.js
@@ -222,7 +222,7 @@ export default class CallLogSection extends RcModule {
   }
 
   /**
-   * Merge isSaving properties from reducer to callsMapping
+   * Merge isSaving property from reducer to callsMapping
    */
   @getter
   callsMapping = createSelector(
@@ -232,7 +232,7 @@ export default class CallLogSection extends RcModule {
   )
 
   /**
-   * Private calls mapping relationship without isSaving properties
+   * Private calls mapping relationship without isSaving property
    */
   get _callsMapping() {
     return this._storage.getItem(this._storageKey).callsMapping;


### PR DESCRIPTION
To solve the issue where ticket saving process cannot be proceeded after the saving process is interrupted by accident, e.g. user refresh the page.