### PR TITLE
bugfix: a workaround to solve the scrollbar issue in safari

### DIFF
--- a/packages/ringcentral-widgets/components/CallItem/styles.scss
+++ b/packages/ringcentral-widgets/components/CallItem/styles.scss
@@ -17,7 +17,6 @@
 .wrapper {
   display: block;
   position: relative;
-  background: #fff;
   height: 69px;
   width: 100%;
   margin-bottom: 1px;


### PR DESCRIPTION
Fix the issue where the scrollbar is under call item element in safari, this is a known issue for Safari. The PR is a workaround to resolve this issue in our situation by removing background color of call item.