### PR TITLE
fix(DetailedPresence): fetch all calls

### DIFF
--- a/packages/ringcentral-integration/enums/subscriptionFilters.js
+++ b/packages/ringcentral-integration/enums/subscriptionFilters.js
@@ -2,7 +2,7 @@ import HashMap from '../lib/HashMap';
 
 export default new HashMap({
   presence: '/account/~/extension/~/presence',
-  detailedPresence: '/account/~/extension/~/presence?detailedTelephonyState=true',
+  detailedPresence: '/account/~/extension/~/presence?detailedTelephonyState=true&totalActiveCalls',
   detailedPresenceWithSip: '/account/~/extension/~/presence?detailedTelephonyState=true&sipData=true',
   accountExtension: '/account/~/extension',
   extensionInfo: '/account/~/extension/~'

--- a/packages/ringcentral-integration/modules/DetailedPresence/index.js
+++ b/packages/ringcentral-integration/modules/DetailedPresence/index.js
@@ -3,6 +3,7 @@ import Presence from '../Presence';
 import actionTypes from './actionTypes';
 import getDetailedPresenceReducer from './getDetailedPresenceReducer';
 import subscriptionFilters from '../../enums/subscriptionFilters';
+import throttle from '../../lib/throttle';
 import {
   isEnded,
   removeInboundRingOutLegs,
@@ -10,6 +11,7 @@ import {
 import proxify from '../../lib/proxy/proxify';
 
 const presenceRegExp = /.*\/presence\?detailedTelephonyState=true&sipData=true/;
+const FETCH_THRESHOLD = 2000;
 
 /**
  * @class
@@ -66,18 +68,28 @@ export default class DetailedPresence extends Presence {
         telephonyStatus,
         presenceStatus,
         userStatus,
+        totalActiveCalls,
       } = message.body;
-      this.store.dispatch({
-        type: this.actionTypes.notification,
-        activeCalls,
-        dndStatus,
-        telephonyStatus,
-        presenceStatus,
-        userStatus,
-        message: message.body.message,
-        lastDndStatus: this.dndStatus,
-        timestamp: Date.now(),
-      });
+
+      /**
+       * as pointed out by Igor in https://jira.ringcentral.com/browse/PLA-33391,
+       * when the real calls count larger than the active calls returned by the pubnub,
+       * we need to pulling the calls manually.
+       */
+      // eslint-disable-next-line no-unused-expressions
+      activeCalls.length < totalActiveCalls
+        ? this.fetchRemainingCalls()
+        : this.store.dispatch({
+          type: this.actionTypes.notification,
+          activeCalls,
+          dndStatus,
+          telephonyStatus,
+          presenceStatus,
+          userStatus,
+          message: message.body.message,
+          lastDndStatus: this.dndStatus,
+          timestamp: Date.now(),
+        });
     }
   }
 
@@ -135,5 +147,9 @@ export default class DetailedPresence extends Presence {
         this._promise = null;
       }
     }
+  }
+
+  async fetchRemainingCalls() {
+    return throttle(this::this._fetch(), FETCH_THRESHOLD);
   }
 }


### PR DESCRIPTION
PubNub Presence notification doesn't return all active calls,this behavior is by design. Because of
payload size limits we provide up to 7 active calls in Presence Push notifications. So we need to
verify `totalActiveCalls` parameter and if the total count is larger than the actual list length,
then we need to go to the Presence API to get all the details.

https://jira.ringcentral.com/browse/PLA-33391