### PR TITLE
refactor(ConferenceCall, ActiveCallsPage, CallCtrlPage, CallsOnholdPage): conference.session->conference.sessionId

### DIFF
--- a/packages/ringcentral-integration/modules/ConferenceCall/getConferenceCallReducer.js
+++ b/packages/ringcentral-integration/modules/ConferenceCall/getConferenceCallReducer.js
@@ -41,7 +41,7 @@ export function getMakeConferenceCallReducer(types) {
   return (state = {}, {
     type,
     conference, // platform conference session data
-    session, // SIP.inviteClientContext instance
+    sessionId, // session id of the conference
     partyProfile,
   }) => {
     const res = {
@@ -54,14 +54,14 @@ export function getMakeConferenceCallReducer(types) {
       case types.updateConferenceSucceeded:
         res[conference.id] = {
           conference,
-          session,
+          sessionId,
           profiles: (res[conference.id] && res[conference.id].profiles) || []
         };
         return res;
       case types.bringInConferenceSucceeded:
         res[conference.id] = {
           conference,
-          session,
+          sessionId,
           profiles: [...res[conference.id].profiles, partyProfile]
         };
         return res;

--- a/packages/ringcentral-widgets/containers/ActiveCallsPage/index.js
+++ b/packages/ringcentral-widgets/containers/ActiveCallsPage/index.js
@@ -162,9 +162,9 @@ function mapToFunctions(_, {
     async mergeToConference(...args) {
       await conferenceCall.mergeToConference(...args);
       const conferenceData = Object.values(conferenceCall.conferences)[0];
-      if (conferenceData && conferenceData.session.id === webphone.activeSessionId) {
+      if (conferenceData && conferenceData.sessionId === webphone.activeSessionId) {
         await sleep(200);
-        webphone.resume(conferenceData.session.id);
+        webphone.resume(conferenceData.sessionId);
       }
     },
     isSessionAConferenceCall(sessionId) {

--- a/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
+++ b/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
@@ -435,17 +435,17 @@ function mapToFunctions(_, {
         : [session];
       await conferenceCall.mergeToConference(webphoneSessions);
       const conferenceData = Object.values(conferenceCall.conferences)[0];
-
+      const conferenceSession = webphone._sessions.get(conferenceData.sessionId);
       if (
         conferenceData
         && !isOnhold
-        && conferenceData.session.isOnHold().local
+        && conferenceSession.isOnHold().local
       ) {
         /**
          * because session termination operation in conferenceCall._mergeToConference,
          * need to wait for webphone.getActiveSessionIdReducer to update
          */
-        webphone.resume(conferenceData.session.id);
+        webphone.resume(conferenceData.sessionId);
         return;
       }
       if (!conferenceData) {

--- a/packages/ringcentral-widgets/containers/CallsOnholdPage/index.js
+++ b/packages/ringcentral-widgets/containers/CallsOnholdPage/index.js
@@ -58,12 +58,14 @@ function mapToFunctions(_, {
         : [session];
       await conferenceCall.mergeToConference(webphoneSessions);
       const conferenceData = Object.values(conferenceCall.conferences)[0];
-      if (conferenceData && conferenceData.session.isOnHold().local) {
+      const conferenceSession = webphone._sessions.get(conferenceData.sessionId);
+
+      if (conferenceData && conferenceSession.isOnHold().local) {
         /**
          * because session termination operation in conferenceCall._mergeToConference,
          * need to wait for webphone.getActiveSessionIdReducer to update
          */
-        webphone.resume(conferenceData.session.id);
+        webphone.resume(conferenceData.sessionId);
       }
     },
     onBackButtonClick() {


### PR DESCRIPTION
since sip instance can not be serialized and tossing around throught workers, then we need to record
the sessionId to do the trick

BREAKING CHANGE: 
* refresh the avatar url when merging
* recording session id instead of sip instance

https://jira.ringcentral.com/browse/RCINT-8072