### PR TITLE
refactor(CallCtrlPage, dev-server): remove router.replace() when merging

### DIFF
--- a/packages/ringcentral-widgets-demo/dev-server/Phone.js
+++ b/packages/ringcentral-widgets-demo/dev-server/Phone.js
@@ -255,7 +255,7 @@ export default class BasePhone extends RcModule {
       ) {
         if (
           routerInteraction.currentPath === '/conferenceCall/mergeCtrl' ||
-          routerInteraction.currentPath === '/conferenceCall/dialer/' ||
+          routerInteraction.currentPath.indexOf('/conferenceCall/dialer/') === 0 ||
           !currentSession
         ) {
           routerInteraction.push('/dialer');

--- a/packages/ringcentral-widgets-demo/dev-server/Phone.js
+++ b/packages/ringcentral-widgets-demo/dev-server/Phone.js
@@ -227,7 +227,7 @@ export default class BasePhone extends RcModule {
 
     webphone._onCallEndFunc = (session, currentSession) => {
       if (
-        routerInteraction.currentPath.indexOf('/conferenceCall/mergeCtrl') === 0 &&
+        routerInteraction.currentPath === '/conferenceCall/mergeCtrl' &&
         webphone.cachedSessions.length && (
           !currentSession ||
           (webphone.cachedSessions.find(cachedSession => cachedSession.id === currentSession.id))
@@ -237,7 +237,7 @@ export default class BasePhone extends RcModule {
       }
 
       if (currentSession
-        && routerInteraction.currentPath.indexOf('/conferenceCall/mergeCtrl') === 0) {
+        && routerInteraction.currentPath === '/conferenceCall/mergeCtrl') {
         const mergingPairFromId = conferenceCall.mergingPair.fromSessionId;
         if (session.id !== mergingPairFromId) {
           routerInteraction.push('/calls/active');
@@ -250,18 +250,18 @@ export default class BasePhone extends RcModule {
           '/conferenceCall/mergeCtrl',
           '/conferenceCall/dialer/',
           '/calls/active'
-        ].find(path => routerInteraction.currentPath.indexOf(path) !== -1) &&
+        ].find(path => routerInteraction.currentPath === path) &&
         (!currentSession || session.id === currentSession.id)
       ) {
         if (
-          routerInteraction.currentPath.indexOf('/conferenceCall/mergeCtrl') === 0 ||
-          routerInteraction.currentPath.indexOf('/conferenceCall/dialer/') === 0 ||
+          routerInteraction.currentPath === '/conferenceCall/mergeCtrl' ||
+          routerInteraction.currentPath === '/conferenceCall/dialer/' ||
           !currentSession
         ) {
           routerInteraction.push('/dialer');
           return;
         }
-        if (routerInteraction.currentPath.indexOf('/calls/active') !== 0) { // mean have params
+        if (routerInteraction.currentPath !== '/calls/active') { // mean have params
           routerInteraction.push('/calls/active');
         }
         routerInteraction.goBack();
@@ -280,8 +280,8 @@ export default class BasePhone extends RcModule {
       );
 
       if (
-        routerInteraction.currentPath.indexOf('/calls/active') !== 0 &&
-        routerInteraction.currentPath.indexOf('/conferenceCall/mergeCtrl') !== 0 &&
+        routerInteraction.currentPath !== '/calls/active' &&
+        routerInteraction.currentPath !== '/conferenceCall/mergeCtrl' &&
         !(isConferenceCallSession && routerInteraction.currentPath === '/calls')
       ) {
         routerInteraction.push('/calls/active');

--- a/packages/ringcentral-widgets-demo/dev-server/Phone.js
+++ b/packages/ringcentral-widgets-demo/dev-server/Phone.js
@@ -250,7 +250,7 @@ export default class BasePhone extends RcModule {
           '/conferenceCall/mergeCtrl',
           '/conferenceCall/dialer/',
           '/calls/active'
-        ].find(path => routerInteraction.currentPath === path) &&
+        ].find(path => routerInteraction.currentPath.indexOf(path) !== -1) &&
         (!currentSession || session.id === currentSession.id)
       ) {
         if (

--- a/packages/ringcentral-widgets-demo/dev-server/containers/App/index.js
+++ b/packages/ringcentral-widgets-demo/dev-server/containers/App/index.js
@@ -157,7 +157,7 @@ export default function App({
                   </DialerAndCallsTabContainer>
                 )} />
               <Route
-                path="/calls/active(/:sessionId)"
+                path="/calls/active"
                 component={() => (
                   <CallCtrlPage
                     showContactDisplayPlaceholder={false}
@@ -269,7 +269,7 @@ export default function App({
                     }} />
                 )} />
               <Route
-                path="/conferenceCall/mergeCtrl(/:sessionId)"
+                path="/conferenceCall/mergeCtrl"
                 component={() => (
                   <ConferenceCallMergeCtrlPage
                     showContactDisplayPlaceholder={false}

--- a/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
+++ b/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
@@ -425,7 +425,6 @@ function mapToFunctions(_, {
       }
     },
     async onMerge(sessionId) {
-      routerInteraction.replace(`${routerInteraction.currentPath}/${sessionId}`);
       const session = webphone._sessions.get(sessionId);
       const isOnhold = session.isOnHold().local;
       conferenceCall.setMergeParty({ toSessionId: sessionId });


### PR DESCRIPTION
On file CllCtrlPage/index.js, we used "routerInteraction.replace(`${routerInteraction.currentPath}/${sessionId}`);" to avoid flickering when merging. Now the issue has gone, so remove it.

BREAKING CHANGE:
* Phone.js: indexOf->=== for conferece call routers
* App:
  * /calls/active(/:sessionId) -> /calls/active
  * /conferenceCall/mergeCtrl(/:sessionId) -> /conferenceCall/mergeCtrl