### PR TITLE
refactor(ActiveCallPanel, CallCtrlPanel, CallCtrlPage, ConferenceCallMergeCtrlPage, App): extract logic into HOC

### DIFF
--- a/packages/ringcentral-widgets-demo/dev-server/containers/App/index.js
+++ b/packages/ringcentral-widgets-demo/dev-server/containers/App/index.js
@@ -278,6 +278,9 @@ export default function App({
                     onBackButtonClick={() => {
                       phone.routerInteraction.push('/calls');
                     }}
+                    onLastCallEnded={() => {
+                      phone.routerInteraction.push('/calls/active');
+                    }}
                   />
                 )} />
               <Route

--- a/packages/ringcentral-widgets/components/ActiveCallPanel/MergeInfo.js
+++ b/packages/ringcentral-widgets/components/ActiveCallPanel/MergeInfo.js
@@ -19,7 +19,7 @@ function MergeInfo(props) {
   const isLastCallEnded = lastCallInfo && lastCallInfo.status === sessionStatus.finished;
   const statusClasses = classnames({
     [styles.callee_status]: true,
-    [styles.callee_status_disconnected]: isLastCallEnded,
+    [styles.callee_status_disconnected]: !!isLastCallEnded,
   });
 
   const isOnConferenCall = !!(

--- a/packages/ringcentral-widgets/components/ActiveCallPanel/MergeInfo.js
+++ b/packages/ringcentral-widgets/components/ActiveCallPanel/MergeInfo.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import sessionStatus from 'ringcentral-integration/modules/Webphone/sessionStatus';
@@ -7,97 +7,77 @@ import styles from './styles.scss';
 import i18n from './i18n';
 import CallAvatar from '../CallAvatar';
 
-class MergeInfo extends Component {
-  static isLastCallEnded({ lastCallInfo }) {
-    return !!(
-      lastCallInfo && lastCallInfo.status === sessionStatus.finished
-    );
-  }
+function MergeInfo(props) {
+  const {
+    currentLocale,
+    timeCounter,
+    lastCallInfo,
+    currentCallTitle,
+    currentCallAvatarUrl,
+  } = props;
 
-  componentWillReceiveProps(nextProps) {
-    if (
-      MergeInfo.isLastCallEnded(this.props) === false
-      && MergeInfo.isLastCallEnded(nextProps) === true
-      && this.props.onLastCallEnded
-    ) {
-      this.props.onLastCallEnded();
-    }
-  }
+  const isLastCallEnded = lastCallInfo && lastCallInfo.status === sessionStatus.finished;
+  const statusClasses = classnames({
+    [styles.callee_status]: true,
+    [styles.callee_status_disconnected]: isLastCallEnded,
+  });
 
-  render() {
-    const {
-      currentLocale,
-      timeCounter,
-      lastCallInfo,
-      currentCallTitle,
-      currentCallAvatarUrl,
-    } = this.props;
+  const isOnConferenCall = !!(
+    lastCallInfo && lastCallInfo.calleeType === calleeTypes.conference
+  );
 
-    const isLastCallEnded = MergeInfo.isLastCallEnded(this.props);
-    const statusClasses = classnames({
-      [styles.callee_status]: true,
-      [styles.callee_status_disconnected]: isLastCallEnded,
-    });
-
-    const isOnConferenCall = !!(
-      lastCallInfo && lastCallInfo.calleeType === calleeTypes.conference
-    );
-
-    return lastCallInfo ? (
-      <div className={styles.mergeInfo}>
-        <div className={styles.merge_item}>
-          <div className={styles.callee_avatar}>
-            <CallAvatar
-              avatarUrl={lastCallInfo.avatarUrl}
-              extraNum={isOnConferenCall ? lastCallInfo.extraNum : 0}
-              isOnConferenceCall={isOnConferenCall}
+  return lastCallInfo ? (
+    <div className={styles.mergeInfo}>
+      <div className={styles.merge_item}>
+        <div className={styles.callee_avatar}>
+          <CallAvatar
+            avatarUrl={lastCallInfo.avatarUrl}
+            extraNum={isOnConferenCall ? lastCallInfo.extraNum : 0}
+            isOnConferenceCall={isOnConferenCall}
             />
-          </div>
-          <div className={styles.callee_name}>
-            {
+        </div>
+        <div className={styles.callee_name}>
+          {
               (lastCallInfo.calleeType === calleeTypes.conference)
                 ? i18n.getString('conferenceCall', currentLocale)
                 : lastCallInfo.name
             }
-          </div>
-          <div className={statusClasses}>
-            {lastCallInfo.status === sessionStatus.finished
+        </div>
+        <div className={statusClasses}>
+          {lastCallInfo.status === sessionStatus.finished
               ? i18n.getString('disconnected', currentLocale)
               : i18n.getString('onHold', currentLocale)}
-          </div>
         </div>
-        <div className={styles.merge_item_active}>
-          <div className={styles.callee_avatar_active} >
-            {
+      </div>
+      <div className={styles.merge_item_active}>
+        <div className={styles.callee_avatar_active} >
+          {
               currentCallAvatarUrl
                 ? <CallAvatar avatarUrl={currentCallAvatarUrl} />
                 : <CallAvatar avatarUrl={null} />
             }
-          </div>
-          <div className={styles.callee_name_active}>
-            {currentCallTitle}
-          </div>
-          <div className={styles.callee_status_active}>
-            {timeCounter}
-          </div>
+        </div>
+        <div className={styles.callee_name_active}>
+          {currentCallTitle}
+        </div>
+        <div className={styles.callee_status_active}>
+          {timeCounter}
         </div>
       </div>
-    ) : (<span />);
-  }
+    </div>
+  ) : (<span />);
 }
 
 MergeInfo.propTypes = {
   currentLocale: PropTypes.string.isRequired,
   timeCounter: PropTypes.element.isRequired,
   lastCallInfo: PropTypes.object,
-  onLastCallEnded: PropTypes.func,
   currentCallTitle: PropTypes.string,
   currentCallAvatarUrl: PropTypes.string,
 };
 
 MergeInfo.defaultProps = {
   lastCallInfo: { calleeType: calleeTypes.unknow },
-  onLastCallEnded: undefined,
   currentCallTitle: undefined,
   currentCallAvatarUrl: undefined,
 };

--- a/packages/ringcentral-widgets/components/ActiveCallPanel/index.js
+++ b/packages/ringcentral-widgets/components/ActiveCallPanel/index.js
@@ -58,7 +58,6 @@ function ActiveCallPanel({
   hasConferenceCall,
   conferenceCallParties,
   lastCallInfo,
-  onLastCallEnded,
 }) {
   const backHeader = showBackButton ? (
     <BackHeader
@@ -89,7 +88,6 @@ function ActiveCallPanel({
         currentLocale={currentLocale}
         timeCounter={timeCounter}
         lastCallInfo={lastCallInfo}
-        onLastCallEnded={onLastCallEnded}
         currentCallAvatarUrl={avatarUrl}
         currentCallTitle={currentCallTitle || fallBackName}
       />);
@@ -208,7 +206,6 @@ ActiveCallPanel.propTypes = {
   conferenceCallEquipped: PropTypes.bool,
   hasConferenceCall: PropTypes.bool,
   lastCallInfo: PropTypes.object,
-  onLastCallEnded: PropTypes.func,
 };
 
 ActiveCallPanel.defaultProps = {
@@ -238,7 +235,6 @@ ActiveCallPanel.defaultProps = {
   hasConferenceCall: false,
   conferenceCallParties: undefined,
   lastCallInfo: undefined,
-  onLastCallEnded: undefined,
 };
 
 export default ActiveCallPanel;

--- a/packages/ringcentral-widgets/components/CallCtrlPanel/index.js
+++ b/packages/ringcentral-widgets/components/CallCtrlPanel/index.js
@@ -174,7 +174,6 @@ class CallCtrlPanel extends Component {
         hasConferenceCall={this.props.hasConferenceCall}
         conferenceCallParties={this.props.conferenceCallParties}
         lastCallInfo={this.props.lastCallInfo}
-        onLastCallEnded={this.props.onLastCallEnded}
       >
         {this.props.children}
         {this.props.showSpinner ? <SpinnerOverlay /> : null}
@@ -246,7 +245,6 @@ CallCtrlPanel.propTypes = {
   conferenceCallEquipped: PropTypes.bool,
   hasConferenceCall: PropTypes.bool,
   lastCallInfo: PropTypes.object,
-  onLastCallEnded: PropTypes.func,
   conferenceCallParties: PropTypes.array,
 };
 
@@ -281,7 +279,6 @@ CallCtrlPanel.defaultProps = {
   hasConferenceCall: false,
   conferenceCallParties: undefined,
   lastCallInfo: undefined,
-  onLastCallEnded: undefined,
 };
 
 export default CallCtrlPanel;

--- a/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
+++ b/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
@@ -2,12 +2,10 @@ import { find } from 'ramda';
 import { connect } from 'react-redux';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import sleep from 'ringcentral-integration/lib/sleep';
 import formatNumber from 'ringcentral-integration/lib/formatNumber';
 import calleeTypes from 'ringcentral-integration/enums/calleeTypes';
 import callDirections from 'ringcentral-integration/enums/callDirections';
 import callingModes from 'ringcentral-integration/modules/CallingSettings/callingModes';
-import sessionStatus from 'ringcentral-integration/modules/Webphone/sessionStatus';
 import withPhone from '../../lib/withPhone';
 import callCtrlLayouts from '../../enums/callCtrlLayouts';
 import CallCtrlPanel from '../../components/CallCtrlPanel';
@@ -190,7 +188,6 @@ class CallCtrlPage extends Component {
         hasConferenceCall={this.props.hasConferenceCall}
         conferenceCallParties={this.props.conferenceCallParties}
         lastCallInfo={this.props.lastCallInfo}
-        onLastCallEnded={this.props.onLastCallEnded}
       >
         {this.props.children}
       </CallCtrlPanel>
@@ -253,7 +250,6 @@ CallCtrlPage.propTypes = {
   conferenceCallEquipped: PropTypes.bool,
   hasConferenceCall: PropTypes.bool,
   lastCallInfo: PropTypes.object,
-  onLastCallEnded: PropTypes.func,
   onIncomingCallCaptured: PropTypes.func,
 };
 
@@ -275,7 +271,6 @@ CallCtrlPage.defaultProps = {
   hasConferenceCall: false,
   conferenceCallParties: undefined,
   lastCallInfo: { calleeType: calleeTypes.unknow },
-  onLastCallEnded: undefined,
   onIncomingCallCaptured: i => i,
 };
 
@@ -290,7 +285,6 @@ function mapToProps(_, {
     contactSearch,
     conferenceCall,
     callingSettings,
-    callMonitor,
   },
   layout = callCtrlLayouts.normalCtrl,
 }) {
@@ -309,7 +303,6 @@ function mapToProps(_, {
   let isOnConference = false;
   let hasConferenceCall = false;
   let isMerging = false;
-  let lastCallInfo;
   let conferenceCallParties;
 
   if (conferenceCall) {
@@ -334,14 +327,6 @@ function mapToProps(_, {
 
     hasConferenceCall = !!conferenceData;
     conferenceCallParties = conferenceCall.partyProfiles;
-    lastCallInfo = callMonitor.lastCallInfo;
-
-    if (
-      layout === callCtrlLayouts.mergeCtrl
-      && (!lastCallInfo || lastCallInfo.status === sessionStatus.finished)
-    ) {
-      mergeDisabled = true;
-    }
   }
 
   layout = isOnConference ? callCtrlLayouts.conferenceCtrl : layout;
@@ -362,7 +347,6 @@ function mapToProps(_, {
     conferenceCallEquipped: !!conferenceCall,
     hasConferenceCall,
     conferenceCallParties,
-    lastCallInfo,
   };
 }
 
@@ -453,10 +437,6 @@ function mapToFunctions(_, {
       }
     },
     onIncomingCallCaptured() {
-      routerInteraction.push('/calls/active');
-    },
-    async onLastCallEnded() {
-      await sleep(2000);
       routerInteraction.push('/calls/active');
     },
   };


### PR DESCRIPTION
Since we have the file ConferenceCallMergeCtrlPage, then we can make it as HOC to store the
onLastCallEnded(), and remove unrelated code out of CallCtrlPage component

BREAKING CHANGE:
* make ConferenceCallMergeCtrlPage as HOC