### PR TITLE
fix(CallMonitor, ActiveCallList): fix 'Disconnected' when merging into conference

### DIFF
--- a/packages/ringcentral-integration/modules/CallMonitor/index.js
+++ b/packages/ringcentral-integration/modules/CallMonitor/index.js
@@ -227,11 +227,11 @@ export default class CallMonitor extends RcModule {
 
     this.addSelector('calls',
       this._selectors.allCalls,
-      () => this._webphone && this._webphone.cachedSessions,
-      (calls, cachedSessions) => (
+      () => this._conferenceCall && this._conferenceCall.isMerging,
+      (calls, isMerging) => (
         calls.filter((callItem) => {
           // filtering out the conferece during merging
-          if (cachedSessions.length) {
+          if (isMerging) {
             return !isConferenceSession(callItem.webphoneSession);
           }
           return true;

--- a/packages/ringcentral-widgets/components/ActiveCallList/index.js
+++ b/packages/ringcentral-widgets/components/ActiveCallList/index.js
@@ -6,7 +6,11 @@ import ActiveCallItem from '../ActiveCallItem';
 import styles from './styles.scss';
 
 function isConferenceCall(normalizedCall) {
-  return normalizedCall.to.phoneNumber.length === 0 && normalizedCall.toName === 'Conference';
+  return normalizedCall
+    && normalizedCall.to
+    && Array.isArray(normalizedCall.to.phoneNumber)
+    && normalizedCall.to.phoneNumber.length === 0
+    && normalizedCall.toName === 'Conference';
 }
 
 function ActiveCallList({


### PR DESCRIPTION
Because we filtering out the conference call when merging, so the lastCallInfo selector won't get
the conference call

https://jira.ringcentral.com/browse/RCINT-8087