### PR TITLE
refactor(ConferenceCall): defending when no ContactMatcher

### DIFF
--- a/packages/ringcentral-integration/modules/ConferenceCall/index.js
+++ b/packages/ringcentral-integration/modules/ConferenceCall/index.js
@@ -35,6 +35,7 @@ function ascendSortParties(parties) {
     'Alert',
     'Call',
     'CallingSettings',
+    'ConnectivityMonitor',
     'Client',
     'Webphone',
     'RolesAndPermissions',
@@ -42,7 +43,14 @@ function ascendSortParties(parties) {
       dep: 'ContactMatcher',
       optional: true
     },
+<<<<<<< HEAD
     { dep: 'ConnectivityMonitor', optional: true },
+=======
+    {
+      dep: 'Webphone',
+      optional: true
+    },
+>>>>>>> refactor(ConnectivityMonitor): make ConnectivityMonitor as necessary dependency
     {
       dep: 'ConferenceCallOptions',
       optional: true

--- a/packages/ringcentral-integration/modules/ConferenceCall/index.js
+++ b/packages/ringcentral-integration/modules/ConferenceCall/index.js
@@ -261,38 +261,25 @@ export default class ConferenceCall extends RcModule {
     const sessionData = webphoneSession.data;
 
     try {
-      if (this._contactMatcher) {
-        const partyProfile = await this._getProfile(webphoneSession);
-        await this._client.service.platform()
-          .post(`/account/~/telephony/sessions/${id}/parties/bring-in`, sessionData);
-
-        const newConference = await this.updateConferenceStatus(id);
-        const conferenceState = this.state.conferences[id];
-        const newParties = ascendSortParties(conferenceState.conference.parties);
-
-        conference = newConference.conference;
-        partyProfile.id = newParties[newParties.length - 1].id;
-
-        // let the contact match to do the matching of the parties.
-        this.store.dispatch({
-          type: this.actionTypes.bringInConferenceSucceeded,
-          conference,
-          sessionId,
-          partyProfile,
-        });
-        return id;
-      }
+      const partyProfile = await this._getProfile(webphoneSession);
 
       await this._client.service.platform()
         .post(`/account/~/telephony/sessions/${id}/parties/bring-in`, sessionData);
 
-      conference = await this.updateConferenceStatus(id);
+      const newConference = await this.updateConferenceStatus(id);
+      conference = newConference.conference;
+
+      if (partyProfile) {
+        const conferenceState = this.state.conferences[id];
+        const newParties = ascendSortParties(conferenceState.conference.parties);
+        partyProfile.id = newParties[newParties.length - 1].id;
+      }
 
       this.store.dispatch({
         type: this.actionTypes.bringInConferenceSucceeded,
         conference,
         sessionId,
-        partyProfile: null,
+        partyProfile,
       });
 
       return id;

--- a/packages/ringcentral-integration/modules/ConferenceCall/index.js
+++ b/packages/ringcentral-integration/modules/ConferenceCall/index.js
@@ -43,14 +43,10 @@ function ascendSortParties(parties) {
       dep: 'ContactMatcher',
       optional: true
     },
-<<<<<<< HEAD
-    { dep: 'ConnectivityMonitor', optional: true },
-=======
     {
       dep: 'Webphone',
       optional: true
     },
->>>>>>> refactor(ConnectivityMonitor): make ConnectivityMonitor as necessary dependency
     {
       dep: 'ConferenceCallOptions',
       optional: true


### PR DESCRIPTION
Because ContactMatcher is optional, then in bringInToConference() and _getProfile(), we need to
check the existence of the module