### PR TITLE
fix(WebPhone, ActiveCallPanel): fix blank page

### DIFF
--- a/packages/ringcentral-integration/modules/Webphone/getWebphoneReducer.js
+++ b/packages/ringcentral-integration/modules/Webphone/getWebphoneReducer.js
@@ -97,6 +97,19 @@ export function getActiveSessionIdReducer(types) {
          * Noticing that the session will remain unhold during the merging.
          */
         return (sessions[0] && sessions[0].id) || null;
+      case types.clearSessionCaching:
+        onHoldSessions =
+          sessions.filter(sessionItem => isOnHold(sessionItem));
+        if (onHoldSessions.length && onHoldSessions[0]) {
+          return onHoldSessions[0].id;
+        }
+        /**
+         * HACK: special scenario-when dialing two number that do not exisit and then we
+         * merge them togother, and the merge process would certainly failed.
+         * Because the numbers are invalid, so the server will hangup them for us.
+         * Noticing that the session will remain unhold during the merging.
+         */
+        return (sessions[0] && sessions[0].id) || state;
       case types.disconnect:
         return null;
       default:

--- a/packages/ringcentral-integration/modules/Webphone/getWebphoneReducer.js
+++ b/packages/ringcentral-integration/modules/Webphone/getWebphoneReducer.js
@@ -98,8 +98,9 @@ export function getActiveSessionIdReducer(types) {
          */
         return (sessions[0] && sessions[0].id) || null;
       case types.clearSessionCaching:
-        onHoldSessions =
-          sessions.filter(sessionItem => isOnHold(sessionItem));
+        onHoldSessions = sessions
+          .filter(sessionItem => !sessionItem.cached)
+          .filter(sessionItem => isOnHold(sessionItem));
         /**
          * Even though we clear session caching after the make the conference call which means
          * there will alway be a outbound call, but need to careful since we it's a hidden

--- a/packages/ringcentral-integration/modules/Webphone/getWebphoneReducer.js
+++ b/packages/ringcentral-integration/modules/Webphone/getWebphoneReducer.js
@@ -100,16 +100,16 @@ export function getActiveSessionIdReducer(types) {
       case types.clearSessionCaching:
         onHoldSessions =
           sessions.filter(sessionItem => isOnHold(sessionItem));
+        /**
+         * Even though we clear session caching after the make the conference call which means
+         * there will alway be a outbound call, but need to careful since we it's a hidden
+         * precondition.
+         */
         if (onHoldSessions.length && onHoldSessions[0]) {
           return onHoldSessions[0].id;
         }
-        /**
-         * HACK: special scenario-when dialing two number that do not exisit and then we
-         * merge them togother, and the merge process would certainly failed.
-         * Because the numbers are invalid, so the server will hangup them for us.
-         * Noticing that the session will remain unhold during the merging.
-         */
-        return (sessions[0] && sessions[0].id) || state;
+        // fall back
+        return (sessions[0] && sessions[0].id) || null;
       case types.disconnect:
         return null;
       default:

--- a/packages/ringcentral-integration/modules/Webphone/index.js
+++ b/packages/ringcentral-integration/modules/Webphone/index.js
@@ -1177,6 +1177,7 @@ export default class Webphone extends RcModule {
   clearSessionCaching() {
     this.store.dispatch({
       type: this.actionTypes.clearSessionCaching,
+      sessions: [...this._sessions.values()].map(normalizeSession),
     });
   }
 

--- a/packages/ringcentral-widgets/components/ActiveCallPanel/MergeInfo.js
+++ b/packages/ringcentral-widgets/components/ActiveCallPanel/MergeInfo.js
@@ -29,7 +29,7 @@ function MergeInfo(props) {
   const isContacts = !!(
     lastCallInfo && lastCallInfo.calleeType === calleeTypes.contacts
   );
-  const calleeName = isContacts ? lastCallInfo.name : formatPhone(lastCallInfo.phoneNumber);
+
   return lastCallInfo ? (
     <div className={styles.mergeInfo}>
       <div className={styles.merge_item}>
@@ -44,7 +44,7 @@ function MergeInfo(props) {
           {
             isOnConferenCall
             ? i18n.getString('conferenceCall', currentLocale)
-            : calleeName
+            : isContacts ? lastCallInfo.name : formatPhone(lastCallInfo.phoneNumber)
           }
         </div>
         <div className={statusClasses}>

--- a/packages/ringcentral-widgets/components/ActiveCallPanel/MergeInfo.js
+++ b/packages/ringcentral-widgets/components/ActiveCallPanel/MergeInfo.js
@@ -42,9 +42,12 @@ function MergeInfo(props) {
         </div>
         <div className={styles.callee_name}>
           {
+            // eslint-disable-next-line no-nested-ternary
             isOnConferenCall
             ? i18n.getString('conferenceCall', currentLocale)
-            : isContacts ? lastCallInfo.name : formatPhone(lastCallInfo.phoneNumber)
+            : isContacts
+              ? lastCallInfo.name
+              : formatPhone(lastCallInfo.phoneNumber)
           }
         </div>
         <div className={statusClasses}>


### PR DESCRIPTION
When merging an onhold active call on merge control page, the old logic will preserve the active
session id as the cached call's id, we need to update it when clear the caching.

BREAKING CHANGE: add sessions into clearSessionCaching() and add `clearSessionCaching` action into
getActiveSessionIdReducer()