### PR TITLE
feat(CallAvatar): show img when url is base64/blob

### DIFF
--- a/packages/ringcentral-widgets/components/CallAvatar/index.js
+++ b/packages/ringcentral-widgets/components/CallAvatar/index.js
@@ -1,8 +1,15 @@
 import React, { Component } from 'react';
+import isBase64 from 'is-base64';
 import PropTypes from 'prop-types';
 import uuid from 'uuid';
 import styles from './styles.scss';
 import SpinnerIcon from '../../assets/images/Spinner.svg';
+
+const REGEXP_BLOB_URL = /^blob:.+\/[\w-]{36,}(?:#.+)?$/;
+
+function isBlobURL(value) {
+  return REGEXP_BLOB_URL.test(value);
+}
 
 class CallAvatar extends Component {
   constructor(props) {
@@ -15,18 +22,26 @@ class CallAvatar extends Component {
   }
 
   loadImg(props = this.props) {
+    const { avatarUrl } = props;
+    if (isBase64(avatarUrl) || isBlobURL(avatarUrl)) {
+      this.setState({
+        avatarUrl
+      });
+    }
+
+    // means we have to load it
     if (!this._mounted) {
       return;
     }
-    if (props.avatarUrl) {
+    if (avatarUrl) {
       const $img = document.createElement('img');
-      $img.src = props.avatarUrl;
+      $img.src = avatarUrl;
       $img.onload = () => {
         if (!this._mounted) {
           return;
         }
         this.setState({
-          avatarUrl: props.avatarUrl
+          avatarUrl
         });
       };
       $img.onerror = () => {
@@ -41,14 +56,24 @@ class CallAvatar extends Component {
     }
   }
 
-  componentDidMount() {
-    this._mounted = true;
-    this.loadImg();
+  componentWillMount() {
+    const { avatarUrl } = this.props;
+
+    if (isBase64(avatarUrl) || isBlobURL(avatarUrl)) {
+      this.loadImg();
+    }
   }
 
-  componentWillReceiveProps(nextProp) {
-    if (nextProp.avatarUrl !== this.props.avatarUrl) {
-      this.loadImg(nextProp);
+  componentDidMount() {
+    this._mounted = true;
+    if (!this.state.avatarUrl) {
+      this.loadImg();
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.avatarUrl !== this.props.avatarUrl) {
+      this.loadImg(nextProps);
     }
   }
 

--- a/packages/ringcentral-widgets/components/CallAvatar/index.js
+++ b/packages/ringcentral-widgets/components/CallAvatar/index.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import isBase64 from 'is-base64';
 import PropTypes from 'prop-types';
 import uuid from 'uuid';
 import styles from './styles.scss';
@@ -23,10 +22,12 @@ class CallAvatar extends Component {
 
   loadImg(props = this.props) {
     const { avatarUrl } = props;
-    if (isBase64(avatarUrl) || isBlobURL(avatarUrl)) {
+
+    if (isBlobURL(avatarUrl)) {
       this.setState({
         avatarUrl
       });
+      return;
     }
 
     // means we have to load it
@@ -57,11 +58,7 @@ class CallAvatar extends Component {
   }
 
   componentWillMount() {
-    const { avatarUrl } = this.props;
-
-    if (isBase64(avatarUrl) || isBlobURL(avatarUrl)) {
-      this.loadImg();
-    }
+    this.loadImg();
   }
 
   componentDidMount() {

--- a/packages/ringcentral-widgets/package.json
+++ b/packages/ringcentral-widgets/package.json
@@ -71,7 +71,6 @@
     "classnames": "^2.2.5",
     "core-js": "^2.5.6",
     "dedent": "^0.7.0",
-    "is-base64": "0.0.6",
     "normalize-css": "^2.3.1",
     "prop-types": "^15.5.10",
     "qs": "^6.5.1",

--- a/packages/ringcentral-widgets/package.json
+++ b/packages/ringcentral-widgets/package.json
@@ -71,6 +71,7 @@
     "classnames": "^2.2.5",
     "core-js": "^2.5.6",
     "dedent": "^0.7.0",
+    "is-base64": "0.0.6",
     "normalize-css": "^2.3.1",
     "prop-types": "^15.5.10",
     "qs": "^6.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5296,11 +5296,7 @@ is-accessor-descriptor@^1.0.0:
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
-
-is-base64@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/is-base64/-/is-base64-0.0.6.tgz#8ee4a3e1f4cbec2a643385705be5c81885347114"
-
+  
 is-binary-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5297,6 +5297,10 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
 
+is-base64@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/is-base64/-/is-base64-0.0.6.tgz#8ee4a3e1f4cbec2a643385705be5c81885347114"
+
 is-binary-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"


### PR DESCRIPTION
When the URL is written in base64 or blob style, set them to the <img/> directly.

BREAKING CHANGE: Add 'is-base64'