### PR TITLE
fix(ConferenceCallMergeCtrlPage): check and trigger the router after mounting

### DIFF
--- a/packages/ringcentral-widgets/containers/ConferenceCallMergeCtrlPage/index.js
+++ b/packages/ringcentral-widgets/containers/ConferenceCallMergeCtrlPage/index.js
@@ -90,6 +90,12 @@ class ConferenceCallMergeContainer extends Component {
 
   componentDidMount() {
     this.mounted = true;
+    /**
+     * if the last has already been terminated after rendering, need to trigger the callback at the point
+     */
+    if (ConferenceCallMergeContainer.isLastCallEnded(this.props)) {
+      this.onLastCallEnded();
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
if the last has already been terminated after rendering, need to trigger the callback at the point