### PR TITLE
feat(CallAvatar): add base64 support

### DIFF
--- a/packages/ringcentral-widgets/components/CallAvatar/index.js
+++ b/packages/ringcentral-widgets/components/CallAvatar/index.js
@@ -5,9 +5,14 @@ import styles from './styles.scss';
 import SpinnerIcon from '../../assets/images/Spinner.svg';
 
 const REGEXP_BLOB_URL = /^blob:.+\/[\w-]{36,}(?:#.+)?$/;
+const REGEXP_BASE64_URL = /^(data:\w+\/[a-zA-Z\+\-\.]+;base64,)?(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/gi;
 
 function isBlobURL(value) {
   return REGEXP_BLOB_URL.test(value);
+}
+
+function isBase64(value) {
+  return REGEXP_BASE64_URL.test(value);
 }
 
 class CallAvatar extends Component {
@@ -23,7 +28,7 @@ class CallAvatar extends Component {
   loadImg(props = this.props) {
     const { avatarUrl } = props;
 
-    if (isBlobURL(avatarUrl)) {
+    if (isBlobURL(avatarUrl) || isBase64(avatarUrl)) {
       this.setState({
         avatarUrl
       });


### PR DESCRIPTION
Because in sfb, we can only get avatar of sfb contacts in base64 formation in C#(still can transform
it to blob in renderer process, but for the sake of performance, we don't do that), so add the
base64 support