### PR TITLE
hotfix(App): temporarily revert the last change for /conferenceCall/mergeCtrl route component, since it is not stable to use

### DIFF
--- a/packages/ringcentral-widgets-demo/dev-server/containers/App/index.js
+++ b/packages/ringcentral-widgets-demo/dev-server/containers/App/index.js
@@ -273,13 +273,10 @@ export default function App({
               <Route
                 path="/conferenceCall/mergeCtrl"
                 component={() => (
-                  <CallCtrlPage
+                  <ConferenceCallMergeCtrlPage
                     showContactDisplayPlaceholder={false}
                     sourceIcons={sourceIcons}
                     getAvatarUrl={getAvatarUrl}
-                    onAdd={() => {
-                      phone.routerInteraction.push('/dialer');
-                    }}
                     onBackButtonClick={() => {
                       phone.routerInteraction.push('/calls');
                     }}


### PR DESCRIPTION
#RCINT-7716