### PR TITLE
fix(CallCtrlPage): fix the issue when open on-hold call in calls tab that still sees the previous merging call

### DIFF
--- a/packages/ringcentral-widgets-demo/dev-server/Phone.js
+++ b/packages/ringcentral-widgets-demo/dev-server/Phone.js
@@ -265,7 +265,7 @@ export default class BasePhone extends RcModule {
 
     webphone.onCallStart(() => {
       if (
-        routerInteraction.currentPath !== '/calls/active'
+        routerInteraction.currentPath.indexOf('/calls/active') !== 0
       ) {
         routerInteraction.push('/calls/active');
       }

--- a/packages/ringcentral-widgets-demo/dev-server/Phone.js
+++ b/packages/ringcentral-widgets-demo/dev-server/Phone.js
@@ -244,14 +244,12 @@ export default class BasePhone extends RcModule {
         (!currentSession || session.id === currentSession.id)
       ) {
         if (
-          routerInteraction.currentPath.indexOf('/calls/active') === 0 ||
-          routerInteraction.currentPath.indexOf('/conferenceCall/dialer/') === 0 ||
           !currentSession
         ) {
           routerInteraction.push('/dialer');
           return;
         }
-        if (routerInteraction.currentPath !== '/calls/active') {
+        if (routerInteraction.currentPath.indexOf('/calls/active') !== 0) {
           routerInteraction.push('/calls/active');
           return;
         }

--- a/packages/ringcentral-widgets-demo/dev-server/Phone.js
+++ b/packages/ringcentral-widgets-demo/dev-server/Phone.js
@@ -227,7 +227,7 @@ export default class BasePhone extends RcModule {
 
     webphone.onCallEnd((session, currentSession) => {
       if (
-        routerInteraction.currentPath === '/calls/active' &&
+        routerInteraction.currentPath.indexOf('/calls/active') === 0 &&
         webphone.cachedSessions.length && (
           !currentSession ||
           (webphone.cachedSessions.find(cachedSession => cachedSession.id === currentSession.id))

--- a/packages/ringcentral-widgets-demo/dev-server/Phone.js
+++ b/packages/ringcentral-widgets-demo/dev-server/Phone.js
@@ -227,7 +227,7 @@ export default class BasePhone extends RcModule {
 
     webphone.onCallEnd((session, currentSession) => {
       if (
-        routerInteraction.currentPath === '/conferenceCall/mergeCtrl' &&
+        routerInteraction.currentPath === '/calls/active' &&
         webphone.cachedSessions.length && (
           !currentSession ||
           (webphone.cachedSessions.find(cachedSession => cachedSession.id === currentSession.id))
@@ -236,24 +236,15 @@ export default class BasePhone extends RcModule {
         return;
       }
 
-      if (currentSession && routerInteraction.currentPath === '/conferenceCall/mergeCtrl') {
-        const { fromSessionId } = conferenceCall.mergingPair;
-        if (session.id !== fromSessionId) {
-          routerInteraction.push('/calls/active');
-          return;
-        }
-      }
-
       if (
         !![
-          '/conferenceCall/mergeCtrl',
           '/conferenceCall/dialer/',
           '/calls/active'
         ].find(path => routerInteraction.currentPath.indexOf(path) !== -1) &&
         (!currentSession || session.id === currentSession.id)
       ) {
         if (
-          routerInteraction.currentPath === '/conferenceCall/mergeCtrl' ||
+          routerInteraction.currentPath === '/calls/active' ||
           routerInteraction.currentPath.indexOf('/conferenceCall/dialer/') === 0 ||
           !currentSession
         ) {
@@ -273,11 +264,6 @@ export default class BasePhone extends RcModule {
     });
 
     webphone.onCallStart((session) => {
-      if (routerInteraction.currentPath.indexOf('/conferenceCall/dialer/') === 0) {
-        routerInteraction.push('/conferenceCall/mergeCtrl');
-        return;
-      }
-
       const isConferenceCallSession = (
         conferenceCall
         && conferenceCall.isConferenceSession(session.id)
@@ -285,7 +271,6 @@ export default class BasePhone extends RcModule {
 
       if (
         routerInteraction.currentPath !== '/calls/active' &&
-        routerInteraction.currentPath !== '/conferenceCall/mergeCtrl' &&
         !(isConferenceCallSession && routerInteraction.currentPath === '/calls')
       ) {
         routerInteraction.push('/calls/active');

--- a/packages/ringcentral-widgets-demo/dev-server/Phone.js
+++ b/packages/ringcentral-widgets-demo/dev-server/Phone.js
@@ -244,7 +244,7 @@ export default class BasePhone extends RcModule {
         (!currentSession || session.id === currentSession.id)
       ) {
         if (
-          routerInteraction.currentPath === '/calls/active' ||
+          routerInteraction.currentPath.indexOf('/calls/active') === 0 ||
           routerInteraction.currentPath.indexOf('/conferenceCall/dialer/') === 0 ||
           !currentSession
         ) {
@@ -263,15 +263,9 @@ export default class BasePhone extends RcModule {
       }
     });
 
-    webphone.onCallStart((session) => {
-      const isConferenceCallSession = (
-        conferenceCall
-        && conferenceCall.isConferenceSession(session.id)
-      );
-
+    webphone.onCallStart(() => {
       if (
-        routerInteraction.currentPath !== '/calls/active' &&
-        !(isConferenceCallSession && routerInteraction.currentPath === '/calls')
+        routerInteraction.currentPath !== '/calls/active'
       ) {
         routerInteraction.push('/calls/active');
       }

--- a/packages/ringcentral-widgets-demo/dev-server/containers/App/index.js
+++ b/packages/ringcentral-widgets-demo/dev-server/containers/App/index.js
@@ -170,6 +170,7 @@ export default function App({
                     onBackButtonClick={() => {
                       phone.routerInteraction.push('/calls');
                     }}
+                    multipleLayout
                   >
                     <RecentActivityContainer
                       getSession={() => (phone.webphone.activeSession || {})}
@@ -282,6 +283,7 @@ export default function App({
                     onBackButtonClick={() => {
                       phone.routerInteraction.push('/calls');
                     }}
+                    multipleLayout
                   />
                 )} />
               <Route

--- a/packages/ringcentral-widgets-demo/dev-server/containers/App/index.js
+++ b/packages/ringcentral-widgets-demo/dev-server/containers/App/index.js
@@ -63,7 +63,6 @@ export default function App({
                   defaultOffsetY={73}
                   hidden={(
                     routerProps.location.pathname === '/calls/active' ||
-                    routerProps.location.pathname === '/conferenceCall/mergeCtrl' ||
                     routerProps.location.pathname.indexOf('/conferenceCall/callsOnhold') === 0 ||
                     routerProps.location.pathname.indexOf('/conferenceCall/dialer') === 0 ||
                     routerProps.location.pathname === '/conferenceCall/participants'
@@ -269,22 +268,6 @@ export default function App({
                     onBack={() => {
                       phone.routerInteraction.push('/calls/active');
                     }} />
-                )} />
-              <Route
-                path="/conferenceCall/mergeCtrl"
-                component={() => (
-                  <CallCtrlPage
-                    showContactDisplayPlaceholder={false}
-                    sourceIcons={sourceIcons}
-                    getAvatarUrl={getAvatarUrl}
-                    onAdd={() => {
-                      phone.routerInteraction.push('/dialer');
-                    }}
-                    onBackButtonClick={() => {
-                      phone.routerInteraction.push('/calls');
-                    }}
-                    multipleLayout
-                  />
                 )} />
               <Route
                 path="/conferenceCall/participants"

--- a/packages/ringcentral-widgets-test/test/integration-test/ConferenceCallDialerPage/ActiveCallPanel.spec.js
+++ b/packages/ringcentral-widgets-test/test/integration-test/ConferenceCallDialerPage/ActiveCallPanel.spec.js
@@ -114,7 +114,7 @@ async function mockStartConference() {
   contactA = phone.contacts.allContacts.find(item => item.type === 'company');
   contactB = phone.contacts.allContacts.find(item => item.type === 'company');
   await mockAddCall(contactA, contactB);
-  expect(phone.routerInteraction.currentPath).toEqual('/conferenceCall/mergeCtrl');
+  expect(phone.routerInteraction.currentPath).toEqual('/calls/active');
   wrapper.update();
   const callCtrlPage = wrapper.find(CallCtrlPage);
   const sessionId = phone.webphone.activeSession.id;
@@ -147,7 +147,7 @@ describe('RCI-1071: simplified call control page #3', () => {
       contactB = phone.contacts.allContacts.find(item => item.type === 'personal' && !item.hasProfileImage);
 
       await mockAddCall(contactA, contactB);
-      expect(phone.routerInteraction.currentPath).toEqual('/conferenceCall/mergeCtrl');
+      expect(phone.routerInteraction.currentPath).toEqual('/calls/active');
       await timeout(3000);
       const mergeInfo = wrapper.find(MergeInfo);
       expect(mergeInfo).toHaveLength(1);
@@ -205,7 +205,7 @@ describe('RCI-1071: simplified call control page #3', () => {
     await timeout(1000);
     await mockSub(1000);
     await timeout(1000);
-    expect(phone.routerInteraction.currentPath).toEqual('/conferenceCall/mergeCtrl');
+    expect(phone.routerInteraction.currentPath).toEqual('/calls/active');
     wrapper.update();
     const mergeInfo = wrapper.find(MergeInfo);
     expect(mergeInfo).toHaveLength(1);
@@ -224,7 +224,7 @@ describe('RCI-1710156: Call control add call flow', () => {
     contactA = phone.contacts.allContacts.find(item => item.type === 'company' && item.hasProfileImage);
     contactB = phone.contacts.allContacts.find(item => item.type === 'personal' && !item.hasProfileImage);
     await mockAddCall(contactA, contactB);
-    expect(phone.routerInteraction.currentPath).toEqual('/conferenceCall/mergeCtrl');
+    expect(phone.routerInteraction.currentPath).toEqual('/calls/active');
     const activeCallButtons = wrapper.find(ActiveCallPad).find(ActiveCallButton);
     expect(activeCallButtons.at(0).props().title).toEqual('Mute');
     expect(activeCallButtons.at(1).props().title).toEqual('Keypad');

--- a/packages/ringcentral-widgets/components/ActiveCallPad/styles.scss
+++ b/packages/ringcentral-widgets/components/ActiveCallPad/styles.scss
@@ -1,6 +1,5 @@
 @import '../../lib/commonStyles/colors.scss';
 @import '../../lib/commonStyles/layout.scss';
-
 $callBtnWidth: 1/3*100%;
 $conferenceCallBtnWidth: 50%;
 $conferenceCallBtnPaddingLeft: ($conferenceCallBtnWidth - $callBtnWidth)/2;
@@ -9,7 +8,6 @@ $buttonAreaWidth:222;
 $totalWidth:300;
 $buttonWidth:45;
 $stopButtonIconRatio:0.98;
-
 .root {
   // max-width: 550px;
   margin-left: auto;
@@ -23,7 +21,7 @@ $stopButtonIconRatio:0.98;
   height: 50%;
 }
 
-.callButton{
+.callButton {
   width: $callBtnWidth;
 }
 
@@ -40,7 +38,6 @@ $stopButtonIconRatio:0.98;
   margin-left: auto;
   margin-right: auto;
   overflow: hidden;
-
   text {
     font-size: 88px;
   }
@@ -59,7 +56,8 @@ $stopButtonIconRatio:0.98;
   circle {
     fill: #5fb95c;
   }
-  g, path {
+  g,
+  path {
     fill: #ffffff;
   }
 }
@@ -72,52 +70,49 @@ $stopButtonIconRatio:0.98;
   height: 100% - $keypadHeight;
   display: block;
   box-sizing: border-box;
-  padding-top: 10px;
-  // padding-bottom: $recent-activity-height;
-
-  .button{
+  padding-top: 10px; // padding-bottom: $recent-activity-height;
+  .button {
     display: inline-block;
     box-sizing: border-box;
     width: $buttonWidth/$buttonAreaWidth/$stopButtonIconRatio*100%;
     max-width: 140px;
   }
-
   .stopButton {
     circle {
       fill: #ff4646;
     }
-    g, path {
+    g,
+    path {
       fill: #ffffff;
     }
   }
 }
 
-.relative{
+.relative {
   position: relative;
 }
 
-.buttonPopup{
+.buttonPopup {
   padding: 10px 10px;
-  text-align:left;
-
-  .buttonItem{
+  text-align: left;
+  min-width: 90px;
+  .buttonItem {
     width: 100%;
     cursor: pointer;
-    overflow:hidden;
+    overflow: hidden;
     font-size: 12px;
     line-height: 12px;
-    padding:10px 20px 10px 0;
+    padding: 10px 20px 10px 0;
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
     justify-content: flex-start;
     align-items: center;
-
-    .buttonName{
+    .buttonName {
       color: #666;
     }
-    .buttonIcon+.buttonName{
-      margin-left:5px;
+    .buttonIcon+.buttonName {
+      margin-left: 5px;
     }
     .buttonActive {
       circle {
@@ -138,7 +133,6 @@ $stopButtonIconRatio:0.98;
       }
       g {
         cursor: default;
-
         &:hover {
           circle {
             stroke: $gray;
@@ -147,32 +141,30 @@ $stopButtonIconRatio:0.98;
       }
     }
   }
-  .buttonItem+.buttonItem{
+  .buttonItem+.buttonItem {
     border-top: .5px solid $silver;
   }
-  .buttonItem.disabled{
+  .buttonItem.disabled {
     cursor: not-allowed;
-
-    .buttonIcon{
+    .buttonIcon {
       color: $silver;
     }
   }
-  .buttonItem:first-of-type{
-    padding-top:0;
+  .buttonItem:first-of-type {
+    padding-top: 0;
   }
-  .buttonItem:last-of-type{
-    padding-bottom:0;
+  .buttonItem:last-of-type {
+    padding-bottom: 0;
   }
 }
 
-.moreButtonContainer{
+.moreButtonContainer {
   display: inline-block;
   width: 33.3333%;
   height: 50%;
   box-sizing: border-box;
-
-  .moreButton{
+  .moreButton {
     height: 100%;
-    width:100%;
+    width: 100%;
   }
 }

--- a/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
+++ b/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
@@ -24,6 +24,7 @@ function mapToProps(_, {
   },
   params,
   children,
+  multipleLayout,
 }) {
   const sessionId = params && params.sessionId;
   let currentSession;
@@ -110,6 +111,7 @@ function mapToProps(_, {
     lastCallInfo,
     children,
     isOnConference,
+    multipleLayout,
   };
 }
 
@@ -127,10 +129,15 @@ function mapToFunctions(_, {
   phoneTypeRenderer,
   recipientsContactInfoRenderer,
   recipientsContactPhoneRenderer,
+  multipleLayout,
 }) {
   return {
     getInitialLayout({ isOnConference, lastCallInfo, session }) {
       let layout = callCtrlLayouts.normalCtrl;
+
+      if (!multipleLayout) {
+        return layout;
+      }
 
       if (isOnConference) {
         return callCtrlLayouts.conferenceCtrl;
@@ -138,13 +145,18 @@ function mapToFunctions(_, {
       const isInboundCall = session.direction === callDirections.inbound;
 
       const { fromSessionId } = conferenceCall.mergingPair;
+      const activeSessionId = webphone && webphone.activeSession && webphone.activeSession.id;
 
       if (!isOnConference &&
          !isInboundCall &&
         (
           fromSessionId &&
-          fromSessionId !== session.id &&
+          (fromSessionId !== session.id) &&
           lastCallInfo
+        ) &&
+        (
+          session.callStatus !== sessionStatus.onHold ||
+          (session.callStatus === sessionStatus.onHold && session.id === activeSessionId)
         )
       ) {
         // enter merge ctrl page.
@@ -264,6 +276,7 @@ CallCtrlContainer.propTypes = {
   children: PropTypes.node,
   showContactDisplayPlaceholder: PropTypes.bool,
   sourceIcons: PropTypes.object,
+  multipleLayout: PropTypes.bool,
 };
 
 CallCtrlContainer.defaultProps = {
@@ -271,6 +284,11 @@ CallCtrlContainer.defaultProps = {
   showContactDisplayPlaceholder: false,
   children: undefined,
   sourceIcons: undefined,
+
+  /**
+   * Set to true to let callctrlpage support handling multiple layouts, false by default.
+   */
+  multipleLayout: false,
 };
 
 export {


### PR DESCRIPTION
fix the issue when open on-hold call in calls tab that still sees the previous merging call

* add a switch in CallCtrlPage to control use multiple layouts supporting
