### PR TITLE
Fixbug/extra log icon of group message

### DIFF
--- a/packages/ringcentral-widgets/components/MessageItem/index.js
+++ b/packages/ringcentral-widgets/components/MessageItem/index.js
@@ -488,7 +488,7 @@ export default class MessageItem extends Component {
             className={styles.actionMenuList}
             currentLocale={currentLocale}
             onLog={
-              isVoicemail || isFax || extraButton ?
+              isVoicemail || isFax || renderExtraButton ?
                 undefined : (onLogConversation && this.logConversation)
             }
             onViewEntity={onViewContact && this.viewSelectedContact}


### PR DESCRIPTION
For group message item, the `renderExtraButton` will return null, so modify judge condition from `extraButton` to `renderExtraButton`.