### PR TITLE
fix(ConferenceCall,CallCtrlPage): fix the issue about conference call dialer page doesn't handle mergingPair correctly

### DIFF
--- a/packages/ringcentral-integration/modules/ConferenceCall/index.js
+++ b/packages/ringcentral-integration/modules/ConferenceCall/index.js
@@ -803,7 +803,7 @@ export default class ConferenceCall extends RcModule {
   }
 
   @proxify
-  async mergeSession({ sessionId, onReadyToMerge }) {
+  async mergeSession({ sessionId, sessionIdToMergeWith, onReadyToMerge }) {
     const session = find(
       x => x.id === sessionId,
       this._webphone.sessions
@@ -812,7 +812,7 @@ export default class ConferenceCall extends RcModule {
     const isSessionOnhold = session.isOnHold;
 
     const sessionToMergeWith = find(
-      x => x.id === this.mergingPair.fromSessionId,
+      x => x.id === (sessionIdToMergeWith || this.mergingPair.fromSessionId),
       this._webphone.sessions
     );
 

--- a/packages/ringcentral-widgets-demo/dev-server/Phone.js
+++ b/packages/ringcentral-widgets-demo/dev-server/Phone.js
@@ -236,7 +236,7 @@ export default class BasePhone extends RcModule {
           return;
         }
         if (session.id === fromSessionIdOfCallsOnhold) {
-          routerInteraction.push('/calls/active');
+          routerInteraction.replace('/calls/active');
           return;
         }
       }

--- a/packages/ringcentral-widgets-demo/dev-server/Phone.js
+++ b/packages/ringcentral-widgets-demo/dev-server/Phone.js
@@ -267,8 +267,11 @@ export default class BasePhone extends RcModule {
           routerInteraction.push('/calls/active');
           return;
         }
-        if (conferenceCall.isMerging) {
-          routerInteraction.push('/calls/active/');
+        const confId = conferenceCall.conferences && Object.keys(conferenceCall.conferences)[0];
+
+        if (conferenceCall.isMerging && confId) {
+          const sessionId = conferenceCall.conferences[confId].sessionId;
+          routerInteraction.push(`/calls/active/${sessionId}`);
           return;
         }
         routerInteraction.goBack();

--- a/packages/ringcentral-widgets-demo/dev-server/containers/App/index.js
+++ b/packages/ringcentral-widgets-demo/dev-server/containers/App/index.js
@@ -261,7 +261,7 @@ export default function App({
                 )}
               />
               <Route
-                path="/conferenceCall/dialer/:fromNumber"
+                path="/conferenceCall/dialer/:fromNumber/:fromSessionId"
                 component={routerProps => (
                   <ConferenceCallDialerPage
                     params={routerProps.params}

--- a/packages/ringcentral-widgets-test/test/integration-test/ConferenceCallDialerPage/ActiveCallPanel.spec.js
+++ b/packages/ringcentral-widgets-test/test/integration-test/ConferenceCallDialerPage/ActiveCallPanel.spec.js
@@ -198,7 +198,7 @@ describe('RCI-1071: simplified call control page #3', () => {
     callCtrlPage.props().onAdd(conferenceSessionId);
     await timeout(500);
     wrapper.update();
-    expect(phone.routerInteraction.currentPath).toEqual(`/conferenceCall/dialer/${conferenceSession.fromNumber}`);
+    expect(phone.routerInteraction.currentPath).toEqual(`/conferenceCall/dialer/${conferenceSession.fromNumber}/${conferenceSession.id}`);
     call({
       phoneNumber: contactA.phoneNumbers[0].phoneNumber,
     });
@@ -274,7 +274,7 @@ describe('RCI-1710156: Call control add call flow', () => {
     addCircleButton.simulate('click');
     wrapper.update();
     const fromNumber = phone.webphone.activeSession.fromNumber;
-    expect(phone.routerInteraction.currentPath).toEqual(`/conferenceCall/dialer/${fromNumber}`);
+    expect(phone.routerInteraction.currentPath).toEqual(`/conferenceCall/dialer/${fromNumber}/${phone.webphone.activeSession.id}`);
     expect(wrapper.find(FromField)).toHaveLength(0);
     expect(wrapper.find(BackHeader)).toHaveLength(1);
     expect(wrapper.find(BackButton).find('.backLabel').text()).toEqual('Active Call');

--- a/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
+++ b/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
@@ -56,12 +56,7 @@ function mapToProps(_, {
     isOnConference = conferenceCall.isConferenceSession(currentSession.id);
     const conferenceData = Object.values(conferenceCall.conferences)[0];
 
-    isMerging = conferenceCall.isMerging && !!(
-      Object
-        .values(conferenceCall.mergingPair)
-        .find(id => id === currentSession.id)
-      || (isOnConference)
-    );
+    isMerging = conferenceCall.isMerging;
 
     if (conferenceData && isWebRTC) {
       conferenceCallId = conferenceData.conference.id;
@@ -215,7 +210,7 @@ function mapToFunctions(_, {
           conferenceCall.setMergeParty({ fromSessionId: sessionId });
         }
         // goto dialer directly
-        routerInteraction.push(`/conferenceCall/dialer/${session.fromNumber}`);
+        routerInteraction.push(`/conferenceCall/dialer/${session.fromNumber}/${sessionId}`);
       }
     },
     onBeforeMerge(sessionId) {

--- a/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
+++ b/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
@@ -203,9 +203,6 @@ function mapToFunctions(_, {
       if (!session || webphone.isCallRecording({ session })) {
         return;
       }
-      if (conferenceCall) {
-        conferenceCall.setMergeParty({ fromSessionId: sessionId });
-      }
       const outBoundOnholdCalls = filter(
         call => call.direction === callDirections.outbound,
         callMonitor.activeOnHoldCalls
@@ -214,6 +211,9 @@ function mapToFunctions(_, {
         // goto 'calls on hold' page
         routerInteraction.push(`/conferenceCall/callsOnhold/${session.fromNumber}/${session.id}`);
       } else {
+        if (conferenceCall) {
+          conferenceCall.setMergeParty({ fromSessionId: sessionId });
+        }
         // goto dialer directly
         routerInteraction.push(`/conferenceCall/dialer/${session.fromNumber}`);
       }

--- a/packages/ringcentral-widgets/containers/CallsOnholdPage/index.js
+++ b/packages/ringcentral-widgets/containers/CallsOnholdPage/index.js
@@ -90,8 +90,17 @@ function mapToFunctions(_, {
         sessionId,
         sessionIdToMergeWith: fromSessionId,
         onReadyToMerge() {
-          routerInteraction.goBack();
+          const confId = conferenceCall.conferences && Object.keys(conferenceCall.conferences)[0];
+
+          if (confId) {
+            const sessionId = conferenceCall.conferences[confId].sessionId;
+
+            routerInteraction.push(`/calls/active/${sessionId}`);
+          } else {
+            routerInteraction.goBack();
+          }
         },
+
       });
     },
     onBackButtonClick() {
@@ -102,7 +111,7 @@ function mapToFunctions(_, {
       phone.routerInteraction.go(-2);
     },
     onAdd() {
-      routerInteraction.push(`/conferenceCall/dialer/${params.fromNumber}`);
+      routerInteraction.push(`/conferenceCall/dialer/${params.fromNumber}/${params.fromSessionId}`);
     },
     getAvatarUrl,
     isConferenceSession: (...args) => conferenceCall.isConferenceSession(...args),

--- a/packages/ringcentral-widgets/containers/CallsOnholdPage/index.js
+++ b/packages/ringcentral-widgets/containers/CallsOnholdPage/index.js
@@ -76,6 +76,8 @@ function mapToFunctions(_, {
   getAvatarUrl,
   ...props
 }) {
+  const { fromSessionId } = params;
+
   const baseProps = mapToBaseFunctions(_, {
     params,
     phone,
@@ -86,6 +88,7 @@ function mapToFunctions(_, {
     async onMerge(sessionId) {
       await conferenceCall.mergeSession({
         sessionId,
+        sessionIdToMergeWith: fromSessionId,
         onReadyToMerge() {
           routerInteraction.goBack();
         },

--- a/packages/ringcentral-widgets/containers/ConferenceCallDialerPage/index.js
+++ b/packages/ringcentral-widgets/containers/ConferenceCallDialerPage/index.js
@@ -55,6 +55,9 @@ function mapToProps(_, {
 function mapToFunctions(_, {
   params,
   phone,
+  phone: {
+    conferenceCall
+  },
   onBack,
   ...props
 }) {
@@ -67,6 +70,19 @@ function mapToFunctions(_, {
     ...baseProps,
     onBack,
     onCallButtonClick() {
+      // set mergingPair if has
+      const { fromSessionId } = params;
+      if (
+        fromSessionId &&
+        conferenceCall &&
+        conferenceCall.mergingPair &&
+        !conferenceCall.mergingPair.fromSessionId
+      ) {
+        conferenceCall.setMergeParty({
+          fromSessionId
+        });
+      }
+
       phone.dialerUI.onCallButtonClick({
         fromNumber: params.fromNumber,
       });


### PR DESCRIPTION
* Change the /conferencecall/dialer router template from "/conferenceCall/dialer/:fromNumber" to
path="/conferenceCall/dialer/:fromNumber/:fromSessionId"
* refine the way to call setMergingPair, only at call button clicked

#RCINT-8432