### PR TITLE
feat(CallMonitor, webphone, ActiveCallsPage, IncomingCallPage): toggle incoming call modal by click

### DIFF
--- a/packages/ringcentral-integration/modules/CallMonitor/callMonitorHelper.js
+++ b/packages/ringcentral-integration/modules/CallMonitor/callMonitorHelper.js
@@ -17,9 +17,13 @@ export function matchWephoneSessionWithAcitveCall(sessions, callItem) {
   const matches = sessions.filter((session) => {
     // Strategy 1: use `P-Rc-Api-Ids` header of a webRTC session to match with `telephonySessionId`
     // and `partyId` of a call data from presence api.
+    // when caller calls him self, the sessionId are the same, so we need the `partyId` to identify the participants.
     if (session.partyData && callItem.telephonySessionId) {
-      const { sessionId } = session.partyData;
-      if (sessionId === callItem.telephonySessionId) {
+      const { sessionId, partyId } = session.partyData;
+      if (
+        sessionId === callItem.telephonySessionId
+        && partyId === callItem.partyId
+      ) {
         return true;
       }
       return false;

--- a/packages/ringcentral-integration/modules/Webphone/index.js
+++ b/packages/ringcentral-integration/modules/Webphone/index.js
@@ -1,4 +1,5 @@
 import { find, filter } from 'ramda';
+import { createSelector } from 'reselect';
 import RingCentralWebphone from 'ringcentral-web-phone';
 import incomingAudio from 'ringcentral-web-phone/audio/incoming.ogg';
 import outgoingAudio from 'ringcentral-web-phone/audio/outgoing.ogg';
@@ -17,6 +18,8 @@ import webphoneErrors from './webphoneErrors';
 import callErrors from '../Call/callErrors';
 import ensureExist from '../../lib/ensureExist';
 import proxify from '../../lib/proxy/proxify';
+import getter from '../../lib/getter';
+
 import {
   isBrowserSupport,
   normalizeSession,
@@ -1485,4 +1488,13 @@ export default class Webphone extends RcModule {
   get connectFailed() {
     return this.connectionStatus === connectionStatus.connectFailed;
   }
+
+  @getter
+  ringingCallOnView = createSelector(
+    () => this.ringSessions,
+    sessions => find(
+      session => !session.minimized,
+      sessions,
+    )
+  )
 }

--- a/packages/ringcentral-widgets/containers/ActiveCallsPage/index.js
+++ b/packages/ringcentral-widgets/containers/ActiveCallsPage/index.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import formatNumber from 'ringcentral-integration/lib/formatNumber';
+import { isRinging } from 'ringcentral-integration/lib/callLogHelpers';
 import callingModes from 'ringcentral-integration/modules/CallingSettings/callingModes';
 import { withPhone } from '../../lib/phoneContext';
 
@@ -156,6 +157,15 @@ function mapToFunctions(_, {
       );
     },
     onCallItemClick(call) {
+      // TODO: Display the ringout call ctrl page.
+      if (!call.webphoneSession) {
+        return;
+      }
+      // show the ring call modal when click a ringing call.
+      if (isRinging(call)) {
+        webphone.toggleMinimized(call.webphoneSession.id);
+        return;
+      }
       if (call.webphoneSession && call.webphoneSession.id) {
         routerInteraction.push(`${callCtrlRoute}/${call.webphoneSession.id}`);
       }

--- a/packages/ringcentral-widgets/containers/IncomingCallPage/index.js
+++ b/packages/ringcentral-widgets/containers/IncomingCallPage/index.js
@@ -213,7 +213,7 @@ function mapToProps(_, {
   showContactDisplayPlaceholder = false,
   phoneTypeRenderer
 }) {
-  const currentSession = webphone.ringSession || {};
+  const currentSession = webphone.ringingCallOnView || {};
   const contactMapping = contactMatcher && contactMatcher.dataMapping;
   const fromMatches = (contactMapping && contactMapping[currentSession.from]) || [];
   const toMatches = (contactMapping && contactMapping[currentSession.to]) || [];


### PR DESCRIPTION
User should be able to go to incoming call control by clicking the in coming call item from All
Calls Tab.

BREAKING CHANGE: 
* add `partyId` in `matchWephoneSessionWithAcitveCall`
* add `ringingCallOnView` selector