### PR TITLE
refine(CallCtrlPage): improve the the mergeDisabled, addDisabled state management to fix a bug that the merge/add button is still enabled after conferenceCall overload

### DIFF
--- a/packages/ringcentral-widgets-demo/dev-server/containers/App/index.js
+++ b/packages/ringcentral-widgets-demo/dev-server/containers/App/index.js
@@ -172,7 +172,6 @@ export default function App({
                     onBackButtonClick={() => {
                       phone.routerInteraction.push('/calls');
                     }}
-                    multipleLayout
                   >
                     <RecentActivityContainer
                       getSession={() => (phone.webphone.activeSession || {})}

--- a/packages/ringcentral-widgets/containers/CallCtrlPage/CallCtrlPage.js
+++ b/packages/ringcentral-widgets/containers/CallCtrlPage/CallCtrlPage.js
@@ -149,33 +149,29 @@ class CallCtrlPage extends Component {
   componentWillReceiveProps(nextProps, nextState) {
     this._updateMergingPairToSessionId(nextProps, nextState);
 
+    let layout = this.state.layout;
     if (nextProps.session.id !== this.props.session.id) {
-      const layout = this.getLayout(this.props, nextProps);
+      layout = this.getLayout(this.props, nextProps);
       this.setState({
         layout,
       });
-      this._updateMergeAddButtonDisabled(nextProps, layout);
 
       if (
         layout === callCtrlLayouts.normalCtrl
       ) {
         this._updateAvatarAndMatchIndex(nextProps);
       }
-    } else {
-      const layout = this.state.layout;
-      this._updateMergeAddButtonDisabled(nextProps, layout);
-
-      if (
-        layout === callCtrlLayouts.mergeCtrl
+    } else if (
+      layout === callCtrlLayouts.mergeCtrl
         && CallCtrlPage.isLastCallEnded(this.props) === false
         && CallCtrlPage.isLastCallEnded(nextProps) === true
-      ) {
-        this.onLastMergingCallEnded();
-      } else if (layout === callCtrlLayouts.conferenceCtrl &&
+    ) {
+      this.onLastMergingCallEnded();
+    } else if (layout === callCtrlLayouts.conferenceCtrl &&
         this.props.conferenceCallParties !== nextProps.conferenceCallParties) {
-        this._updateCurrentConferenceCall(nextProps);
-      }
+      this._updateCurrentConferenceCall(nextProps);
     }
+    this._updateMergeAddButtonDisabled(nextProps, layout);
   }
 
   _updateMergeAddButtonDisabled(nextProps, layout) {

--- a/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
+++ b/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
@@ -43,8 +43,6 @@ function mapToProps(_, {
 
   const isWebRTC = callingSettings.callingMode === callingModes.webphone;
   const isInboundCall = currentSession.direction === callDirections.inbound;
-  let mergeDisabled = !isWebRTC || isInboundCall || !currentSession.partyData;
-  let addDisabled = !isWebRTC || isInboundCall || !currentSession.partyData;
 
   let isOnConference = false;
   let hasConferenceCall = false;
@@ -52,6 +50,7 @@ function mapToProps(_, {
   let conferenceCallParties;
   let conferenceCallId = null;
   const lastCallInfo = callMonitor.lastCallInfo;
+  let isConferenceCallOverload = false;
   const conferenceCallEquipped =
     !!(conferenceCall && rolesAndPermissions.hasConferenceCallPermission);
   if (conferenceCallEquipped) {
@@ -62,11 +61,7 @@ function mapToProps(_, {
 
     if (conferenceData && isWebRTC) {
       conferenceCallId = conferenceData.conference.id;
-      const overload = conferenceCall.isOverload(conferenceCallId);
-      if (overload) {
-        mergeDisabled = true;
-        addDisabled = true;
-      }
+      isConferenceCallOverload = conferenceCall.isOverload(conferenceCallId);
     }
 
     hasConferenceCall = !!conferenceData;
@@ -99,8 +94,6 @@ function mapToProps(_, {
     showBackButton: true, // callMonitor.calls.length > 0,
     searchContactList: contactSearch.sortedResult,
     showSpinner: isMerging,
-    addDisabled,
-    mergeDisabled,
     conferenceCallEquipped,
     hasConferenceCall,
     conferenceCallParties,
@@ -108,6 +101,8 @@ function mapToProps(_, {
     lastCallInfo,
     children,
     isOnConference,
+    isWebRTC,
+    isConferenceCallOverload,
   };
 }
 

--- a/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
+++ b/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
@@ -25,7 +25,6 @@ function mapToProps(_, {
   },
   params,
   children,
-  multipleLayout,
 }) {
   const sessionId = params && params.sessionId;
   let currentSession;
@@ -109,7 +108,6 @@ function mapToProps(_, {
     lastCallInfo,
     children,
     isOnConference,
-    multipleLayout,
   };
 }
 
@@ -127,13 +125,17 @@ function mapToFunctions(_, {
   phoneTypeRenderer,
   recipientsContactInfoRenderer,
   recipientsContactPhoneRenderer,
-  multipleLayout,
 }) {
   return {
-    getInitialLayout({ isOnConference, lastCallInfo, session }) {
+    getInitialLayout({
+      conferenceCallEquipped,
+      isOnConference,
+      lastCallInfo,
+      session
+    }) {
       let layout = callCtrlLayouts.normalCtrl;
 
-      if (!multipleLayout) {
+      if (!conferenceCallEquipped) {
         return layout;
       }
 
@@ -266,7 +268,6 @@ CallCtrlContainer.propTypes = {
   children: PropTypes.node,
   showContactDisplayPlaceholder: PropTypes.bool,
   sourceIcons: PropTypes.object,
-  multipleLayout: PropTypes.bool,
 };
 
 CallCtrlContainer.defaultProps = {
@@ -274,11 +275,6 @@ CallCtrlContainer.defaultProps = {
   showContactDisplayPlaceholder: false,
   children: undefined,
   sourceIcons: undefined,
-
-  /**
-   * Set to true to let callctrlpage support handling multiple layouts, false by default.
-   */
-  multipleLayout: false,
 };
 
 export {


### PR DESCRIPTION
* remove the multipleLayout switch prop as we should use the "conferenceCallEquipped" prop to detect layout
* move the mergeDisabled, addDisabled into CallCtrlPage