### PR TITLE
Users who are not activated add a new status to highlight this status

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,7 @@
     "*.html.tmpl": "html",
     ".babelrc": "jsonc"
   },
-  "editor.rulers": [
-    100
-  ],
+  "editor.rulers": [100],
   "editor.tabSize": 2,
   "search.exclude": {
     "**/node_modules": true,
@@ -27,7 +25,6 @@
   "[javascript]": {
     "editor.formatOnSave": false
   },
-
   // Allow formatting for other languages
   "editor.formatOnSave": true,
 

--- a/packages/ringcentral-integration/README.md
+++ b/packages/ringcentral-integration/README.md
@@ -5,7 +5,6 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/39f7f85c990b4eeab98702c89cdd31d3)](https://www.codacy.com/app/RingCentral/ringcentral-js-widgets?utm_source=github.com&utm_medium=referral&utm_content=ringcentral/ringcentral-js-widgets&utm_campaign=badger)
 [![NPM Version](https://img.shields.io/npm/v/ringcentral-integration.svg?style=flat-square)](https://www.npmjs.com/package/ringcentral-integration)
 
-
 ## Introduction
 
 RingCentral integration common library aims to provide reusable modules to allow developers to integrate RingCentral unified communication service into third party processes or tools more easily.
@@ -39,7 +38,6 @@ class Phone extends RcModule {
 const phone = new Phone();
 const store = createStore(phone.reducer);
 phone.setStore(store);
-
 ```
 
 Now you are armed with a set of RingCentral services.
@@ -49,22 +47,29 @@ Now you are armed with a set of RingCentral services.
 ## High Level Concept
 
 ### Module
+
 Module is the basic component, which usually wraps one ore more API calls to provide common used features. A good example to understand module is to compare Call Log related features in `RingCentral JS Client` and `RingCentral Integration Common Library`. In `RingCentral JS Client`, you can get call log with following code
 
 ```javascript
-client.account().extension().callLog().list({
-	...param
-})
+client
+    .account()
+    .extension()
+    .callLog()
+    .list({
+        ...param,
+    });
 ```
 
 There are three kind of modules:
-1. Root module, which provides all other modules for app. Root module also have a duty to provide redux store, this will be discussed more in later sections.
-2. Common modules, which holds a part of functions provided by api.
-3. Custom modules, when common modules can not fulfill your need, you develop one yourself.
+
+1.  Root module, which provides all other modules for app. Root module also have a duty to provide redux store, this will be discussed more in later sections.
+2.  Common modules, which holds a part of functions provided by api.
+3.  Custom modules, when common modules can not fulfill your need, you develop one yourself.
 
 ### Root Module
 
 All needed common modules which are provided by `ringcentral-integration` can be listed here. And also other modules composed by you.
+
 ```javascript
 import Alert from 'ringcentral-integration/modules/Alert';
 import Brand from 'ringcentral-integration/modules/Brand';
@@ -73,104 +78,116 @@ import Brand from 'ringcentral-integration/modules/Brand';
 // other variables initialized here
 
 @ModuleFactory({
-  providers: [
-    { provide: 'Alert', useClass: Alert },
-    { provide: 'Brand', useClass: Brand },
-    {
-      provide: 'EnvironmentOptions',
-      useFactory: ({ sdkConfig }) => sdkConfig,
-      deps: [
-        { dep: 'SdkConfig' },
-      ],
-    },
-    {
-      provide: 'SdkConfig',
-      useValue: {
-        ...apiConfig,
-        cachePrefix: `sdk-${prefix}`,
-        clearCacheOnRefreshError: false,
-      },
-    },
-    {
-      provide: 'ContactSources',
-      useFactory: ({ glipContacts }) =>
-        [glipContacts],
-      deps: ['GlipContacts']
-    },
-  ]
+    providers: [
+        { provide: 'Alert', useClass: Alert },
+        { provide: 'Brand', useClass: Brand },
+        {
+            provide: 'EnvironmentOptions',
+            useFactory: ({ sdkConfig }) => sdkConfig,
+            deps: [{ dep: 'SdkConfig' }],
+        },
+        {
+            provide: 'SdkConfig',
+            useValue: {
+                ...apiConfig,
+                cachePrefix: `sdk-${prefix}`,
+                clearCacheOnRefreshError: false,
+            },
+        },
+        {
+            provide: 'ContactSources',
+            useFactory: ({ glipContacts }) => [glipContacts],
+            deps: ['GlipContacts'],
+        },
+    ],
 })
 export default class BaseRoot extends RcModule {}
 ```
 
 #### Custom Modules
+
 There are two ways to custom modules:
-1. Extends `RcModule` and set dependencies by decorators
-2. Extends directly a build-in module
+
+1.  Extends `RcModule` and set dependencies by decorators
+2.  Extends directly a build-in module
 
 ##### Extends RcModule
+
 ```javascript
 @Module({
-  deps: [
-    'AccountExtension',
-    'GlipPersons',
-    { dep: 'GlipContactsOptions', optional: true }
-  ]
+    deps: [
+        'AccountExtension',
+        'GlipPersons',
+        { dep: 'GlipContactsOptions', optional: true },
+    ],
 })
-export default class GlipContacts extends RcModule {
-}
+export default class GlipContacts extends RcModule {}
 ```
 
 ##### Extends Build-in Module
+
 ```javascript
 @Module({
-  deps: []
+    deps: [],
 })
-export default class NewGlipGroups extends GlipGroups {
-}
+export default class NewGlipGroups extends GlipGroups {}
 ```
 
 #### Module Providers
+
 Two steps to set providers for root module.
 
 Step 1. Set common moduels
-```javascript
 
+```javascript
 @ModuleFactory({
-  providers: [
-    { provide: 'Alert', useClass: Alert },
-    { provide: 'Brand', useClass: Brand },
-  ]
+    providers: [
+        { provide: 'Alert', useClass: Alert },
+        { provide: 'Brand', useClass: Brand },
+    ],
 })
 export default class BaseRoot extends RcModule {
-  initialize() {
-    // ...initialize stuff here
-  }
+    initialize() {
+        // ...initialize stuff here
+    }
 }
 ```
+
 Step 2. Set self composed modules by HOC
+
 ```javascript
 function createRootModule({ apiConfig, redirectUri }) {
-  @ModuleFactory({
-    providers: [
-      {provide: 'SDKConfig', useValue: {...apiConfig, cachePrefix: `sdk-${prefex}`}},
-      { provide: 'OAuthOptions', useValue: { redirectUri }, spread: true },
-    ]
-  })
-  class Root extends RcModule {}
+    @ModuleFactory({
+        providers: [
+            {
+                provide: 'SDKConfig',
+                useValue: { ...apiConfig, cachePrefix: `sdk-${prefex}` },
+            },
+            {
+                provide: 'OAuthOptions',
+                useValue: { redirectUri },
+                spread: true,
+            },
+        ],
+    })
+    class Root extends RcModule {}
 
-  return Root.create();
+    return Root.create();
 }
 ```
 
 ##### How It Works
+
 There's no action creator in modules. All actions are in an Enum instance.
 
 `RcModule`'s default implementation included a method: `initialize()`, it's definition is:
+
 ```javascript
   initialize() {
     this.store.subscribe(() => this._onStateChange());
   }
 ```
+
 Generally you dont have to do any thing to change this implementation. Just get your `_onStateChange`
 method done.
 
@@ -199,8 +216,8 @@ Get what you want from state.
 
 #### Module Store
 
-1. Store can only be set to **Root Module**.
-2. Store can noly be set once
+1.  Store can only be set to **Root Module**.
+2.  Store can noly be set once
 
 ```javascript
   setStore(store) {
@@ -230,10 +247,10 @@ Get what you want from state.
   }
 ```
 
-`setStore` methods also triggers module initialization. 
+`setStore` methods also triggers module initialization.
 
-1. All sub modules' `_setStore` methods are called too.
-2. All sub modules. And in every module, the `initizlize` methods is called. 
+1.  All sub modules' `_setStore` methods are called too.
+2.  All sub modules. And in every module, the `initizlize` methods is called.
 
 ```javascript
   setStore(store) {
@@ -269,9 +286,10 @@ Get what you want from state.
 In `initialize` method, it may subscribe the store to state change.
 
 #### Module's create method
-1. Get all modules' value (if this module is `ValueProvider`) or instances.
-In this step. all providers are resolved and set them to Root Module instance, key is the provider's token and instance is the provider's instance.
-2. Get all sub modules' reducers, combine them then set it to Root Module's `_reducer` field.
+
+1.  Get all modules' value (if this module is `ValueProvider`) or instances.
+    In this step. all providers are resolved and set them to Root Module instance, key is the provider's token and instance is the provider's instance.
+2.  Get all sub modules' reducers, combine them then set it to Root Module's `_reducer` field.
 
 ### Phone
 
@@ -291,6 +309,7 @@ const phone = new Phone();
 ```
 
 ### Store
+
 As Phone object is built up with Redux, after Phone object is created, you need to use following code to create Redux store
 
 ```javascript
@@ -299,47 +318,51 @@ phone.setStore(store);
 ```
 
 ### Action
+
 Actions are defined in Enum, which will be discussed in next section.
+
 ```javascript
-export default new Enum([
-  ...Object.keys(moduleActionTypes),
-  'alert',
-  'dismiss',
-  'dismissAll',
-], 'alert');
+export default new Enum(
+    [...Object.keys(moduleActionTypes), 'alert', 'dismiss', 'dismissAll'],
+    'alert',
+);
 ```
 
-After initilized with `Enum`, it will be an `map`. It's key are just those *string*: `alert`, `dismiss` and `dismissAll`, but values are `alert-alert`, `alert-dismiss`, `alert-dismissAll`.
-All start with prefix *alert*.
+After initilized with `Enum`, it will be an `map`. It's key are just those _string_: `alert`, `dismiss` and `dismissAll`, but values are `alert-alert`, `alert-dismiss`, `alert-dismissAll`.
+All start with prefix _alert_.
 
 You can use it like:
+
 ```javascript
 export function getMessagesReducer(types) {
-  return (state = [], type) => {
-    switch (type) {
-      case types.alert:
-        return [
-          ...state,
-          {
-            // ...
-          },
-        ];
-      case types.dismiss:
-        return // state
-      case types.dismissAll:
-        return [];
-      default:
-        return state;
-    }
-  };
+    return (state = [], type) => {
+        switch (type) {
+            case types.alert:
+                return [
+                    ...state,
+                    {
+                        // ...
+                    },
+                ];
+            case types.dismiss:
+                return; // state
+            case types.dismissAll:
+                return [];
+            default:
+                return state;
+        }
+    };
 }
 ```
+
 Please notice `getMessagesReducer` is a high order function. It will return a function which is the reducer you want.
 
 Every module has its needed actions defined within the module with `Enum`.
 
 ### Enum
+
 This is simple, just take the code:
+
 ```javascript
 // How it's called
 export default new Enum([
@@ -359,18 +382,22 @@ export default class Enum extends HashMap {
   }
 }
 ```
+
 The array parameter values are key, and values are prefix (the second parameter) and values.
+
 ```js
-values.forEach((value) => {
-  definition[value] = prefix !== '' ? `${prefix}-${value}` : value;
+values.forEach(value => {
+    definition[value] = prefix !== '' ? `${prefix}-${value}` : value;
 });
 ```
+
 Code is clear!
 
 ### DI
-1. Module decorator ==> registerModule
-2. Lib decorator ==> registerModule
-3. ModuleFactory decorator ==> registerModuleFactory
+
+1.  Module decorator ==> registerModule
+2.  Lib decorator ==> registerModule
+3.  ModuleFactory decorator ==> registerModuleFactory
 
 What's in common is that all these registered modules are stored in a map instance with the `Class` as key
 and `metadata` as the value.
@@ -378,12 +405,14 @@ and `metadata` as the value.
 When does DI work is when **Root Module** called `create()` method. In the method, `Injector` class started to handle those `Module`, `Library` and `ModuleFactory` decorator and to make dependency injection by its `addModule` method
 .
 
-In the same time, modules' reducers and state are also initialized and set to module by the methods prefixed by **_**.
+In the same time, modules' reducers and state are also initialized and set to module by the methods prefixed by **\_**.
 
 #### Module
+
 When one module has dependencies on other modules.
 
 How to use:
+
 ```javascript
 @Module({
   deps: [{ dep: 'AlertOptions', optional: true }]
@@ -397,61 +426,169 @@ In the map, key is `Alert` class and value is `{ dep: 'AlertOptions', optional: 
 
 #### Provider
 
+#### ModuleFactory
+
+This decorator can be used on any kind modules, no matter it's root module or not.
+
+## Play with Development Server
+
+A development server is delivered with source so that developers can use it to get familiar with the project or do further development. To get development server running
+
+After initilized with `Enum`, it will be an `map`. It's key are just those _string_: `alert`, `dismiss` and `dismissAll`, but values are `alert-alert`, `alert-dismiss`, `alert-dismissAll`.
+All start with prefix _alert_.
+
+You can use it like:
+
+```javascript
+export function getMessagesReducer(types) {
+    return (state = [], type) => {
+        switch (type) {
+            case types.alert:
+                return [
+                    ...state,
+                    {
+                        // ...
+                    },
+                ];
+            case types.dismiss:
+                return; // state
+            case types.dismissAll:
+                return [];
+            default:
+                return state;
+        }
+    };
+}
+```
+
+Please notice `getMessagesReducer` is a high order function. It will return a function which is the reducer you want.
+
+Every module has its needed actions defined within the module with `Enum`.
+
+### Enum
+
+This is simple, just take the code:
+
+```javascript
+// How it's called
+export default new Enum([
+  'alert',
+  'dismiss',
+  'dismissAll',
+], 'alert');
+
+// Enum defination
+export default class Enum extends HashMap {
+  constructor(values = [], prefix = '') {
+    const definition = {};
+    values.forEach((value) => {
+      definition[value] = prefix !== '' ? `${prefix}-${value}` : value;
+    });
+    super(definition);
+  }
+}
+```
+
+The array parameter values are key, and values are prefix (the second parameter) and values.
+
+```js
+values.forEach(value => {
+    definition[value] = prefix !== '' ? `${prefix}-${value}` : value;
+});
+```
+
+Code is clear!
+
+### DI
+
+1.  Module decorator ==> registerModule
+2.  Lib decorator ==> registerModule
+3.  ModuleFactory decorator ==> registerModuleFactory
+
+What's in common is that all these registered modules are stored in a map instance with the `Class` as key
+and `metadata` as the value.
+
+When does DI work is when **Root Module** called `create()` method. In the method, `Injector` class started to handle those `Module`, `Library` and `ModuleFactory` decorator and to make dependency injection by its `addModule` method
+.
+
+In the same time, modules' reducers and state are also initialized and set to module by the methods prefixed by **\_**.
+
+#### Module
+
+When one module has dependencies on other modules.
+
+How to use:
+
+```javascript
+@Module({
+  deps: [{ dep: 'AlertOptions', optional: true }]
+})
+export default class Alert extends RcModule {
+  // ..
+}
+
+In the map, key is `Alert` class and value is `{ dep: 'AlertOptions', optional: true }.
+```
+
+#### Provider
 
 #### ModuleFactory
+
 This decorator can be used on any kind modules, no matter it's root module or not.
 
 ## Dependency Injection
+
 Please refer to [Dependency Injection](docs/dependency-injection.md) for more details.
 
 ## Modules
+
 ---
 
-- [x] AccountExtension
-- [x] AccountInfo
-- [x] AccountPhoneNumber
-- [x] Alert
-- [x] Auth
-- [x] AddressBook
-- [x] BlockedNumber
-- [x] Brand
-- [x] Call
-- [x] CallingSettings
-- [x] ComposeText
-- [x] ConnectivityMonitor
-- [x] Conversation
-- [x] ContactSearch
-- [x] Contacts
-- [x] DialingPlan
-- [x] DetailedPresence
-- [x] Environment
-- [x] ExtensionInfo
-- [x] ExtensionPhoneNumber
-- [x] ExtensionDevice
-- [x] GlobalStorage
-- [x] Locale
-- [x] MessageSender
-- [x] MessageStore
-- [x] Messages
-- [x] NumberValidate
-- [x] Presence
-- [x] RateLimiter
-- [x] RecentCalls
-- [x] RecentMessages
-- [x] RegionSettings
-- [x] Ringout
-- [x] RolesAndPermissions
-- [x] Softphone
-- [x] Storage
-- [x] Subscription
-- [x] TabManager
-- [x] Webphone
-- more...
+*   [x] AccountExtension
+*   [x] AccountInfo
+*   [x] AccountPhoneNumber
+*   [x] Alert
+*   [x] Auth
+*   [x] AddressBook
+*   [x] BlockedNumber
+*   [x] Brand
+*   [x] Call
+*   [x] CallingSettings
+*   [x] ComposeText
+*   [x] ConnectivityMonitor
+*   [x] Conversation
+*   [x] ContactSearch
+*   [x] Contacts
+*   [x] DialingPlan
+*   [x] DetailedPresence
+*   [x] Environment
+*   [x] ExtensionInfo
+*   [x] ExtensionPhoneNumber
+*   [x] ExtensionDevice
+*   [x] GlobalStorage
+*   [x] Locale
+*   [x] MessageSender
+*   [x] MessageStore
+*   [x] Messages
+*   [x] NumberValidate
+*   [x] Presence
+*   [x] RateLimiter
+*   [x] RecentCalls
+*   [x] RecentMessages
+*   [x] RegionSettings
+*   [x] Ringout
+*   [x] RolesAndPermissions
+*   [x] Softphone
+*   [x] Storage
+*   [x] Subscription
+*   [x] TabManager
+*   [x] Webphone
+*   more...
 
 ## Contribution
+
 ---
 
 Please fork the project and read the following:
 
-- [Contribution Guide](docs/contribute.md)
-
+*   [Contribution Guide](docs/contribute.md)

--- a/packages/ringcentral-integration/lib/DataFetcher/index.js
+++ b/packages/ringcentral-integration/lib/DataFetcher/index.js
@@ -259,6 +259,7 @@ export default class DataFetcher extends Pollable {
   async _fetchWithForbiddenCheck() {
     try {
       const data = await this._fetchFunction();
+      console.log('=====>fetch data', data);
       return data;
     } catch (error) {
       if (

--- a/packages/ringcentral-integration/modules/AccountContacts/accountContactsHelper.js
+++ b/packages/ringcentral-integration/modules/AccountContacts/accountContactsHelper.js
@@ -1,0 +1,13 @@
+/**
+ * Create a account extension checker to verify if an extension can be cached
+ * @param {boolean} checkStatus Need to check status of an extension
+ */
+export function createChecker(checkStatus = true) {
+  return (extension) => {
+    if (checkStatus) {
+      return extension.status === 'Enabled' &&
+      ['DigitalUser', 'User', 'Department'].indexOf(extension.type) >= 0;
+    }
+    return ['DigitalUser', 'User', 'Department'].indexOf(extension.type) >= 0;
+  };
+}

--- a/packages/ringcentral-integration/modules/AccountContacts/index.js
+++ b/packages/ringcentral-integration/modules/AccountContacts/index.js
@@ -97,6 +97,7 @@ export default class AccountContacts extends RcModule {
             phoneNumbers: [{ phoneNumber: extension.ext, phoneType: 'extension' }],
             profileImageUrl: profileImages[id] && profileImages[id].imageUrl,
             presence: presences[id] && presences[id].presence,
+            contactStatus: extension.status,
           };
           contact.name = `${contact.firstName || ''} ${contact.lastName || ''}`;
           if (isBlank(contact.extensionNumber)) {

--- a/packages/ringcentral-integration/modules/AccountExtension/accountExtensionHelper.js
+++ b/packages/ringcentral-integration/modules/AccountExtension/accountExtensionHelper.js
@@ -5,11 +5,36 @@
  * @return {Boolean}
  */
 export function isEssential(ext) {
-  return ext.extensionNumber &&
+  return (
+    ext.extensionNumber &&
     ext.extensionNumber !== '' &&
-    ext.status === 'Enabled' &&
-    ['DigitalUser', 'User', 'Department'].indexOf(ext.type) >= 0;
+    /* ext.status === 'Enabled' && */
+    ['DigitalUser', 'User', 'Department'].indexOf(ext.type) >= 0
+  );
 }
+
+/**
+ * Create a account extension checker to verify if an extension can be cached
+ * @param {boolean} checkStatus
+ */
+export function createEssentialChecker(checkStatus = true) {
+  return (ext) => {
+    if (checkStatus) {
+      return (
+        ext.extensionNumber &&
+        ext.extensionNumber !== '' &&
+        ext.status === 'Enabled' &&
+        ['DigitalUser', 'User', 'Department'].indexOf(ext.type) >= 0
+      );
+    }
+    return (
+      ext.extensionNumber &&
+      ext.extensionNumber !== '' &&
+      ['DigitalUser', 'User', 'Department'].indexOf(ext.type) >= 0
+    );
+  };
+}
+
 /**
  * @function
  * @description Returns a simplified extension data for caching to reducer storage use

--- a/packages/ringcentral-integration/modules/AccountExtension/index.js
+++ b/packages/ringcentral-integration/modules/AccountExtension/index.js
@@ -13,6 +13,7 @@ import {
 } from './getAccountExtensionReducer';
 import {
   isEssential,
+  createEssentialChecker,
   simplifyExtensionData,
 } from './accountExtensionHelper';
 import subscriptionFilters from '../../enums/subscriptionFilters';
@@ -20,6 +21,7 @@ import proxify from '../../lib/proxy/proxify';
 
 const extensionRegExp = /.*\/extension$/;
 const DEFAULT_TTL = 24 * 60 * 60 * 1000;
+const DEFAULT_STATUS_VALUE = true;
 
 /**
  * @class
@@ -43,6 +45,7 @@ export default class AccountExtension extends DataFetcher {
     client,
     rolesAndPermissions,
     ttl = DEFAULT_TTL,
+    needCheckStatus = DEFAULT_STATUS_VALUE,
     ...options
   }) {
     super({
@@ -57,9 +60,11 @@ export default class AccountExtension extends DataFetcher {
       subscriptionHandler: async (message) => {
         this._subscriptionHandleFn(message);
       },
-      fetchFunction: async () => (await fetchList(params => (
-        this._client.account().extension().list(params)
-      ))).filter(isEssential).map(simplifyExtensionData),
+      fetchFunction: async () => (await fetchList((params) => {
+        const fetchRet = this._client.account().extension().list(params);
+        console.log('#####', fetchRet);
+        return fetchRet;
+      })).filter(createEssentialChecker(needCheckStatus)).map(simplifyExtensionData),
       readyCheckFn: () => this._rolesAndPermissions.ready,
     });
 

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/en-US.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/en-US.js
@@ -10,5 +10,6 @@ export default {
   [presenceStatus.available]: 'Available',
   [presenceStatus.offline]: 'Invisible',
   [presenceStatus.busy]: 'Busy',
-  [dndStatus.doNotAcceptAnyCalls]: 'Do not Disturb'
+  [dndStatus.doNotAcceptAnyCalls]: 'Do not Disturb',
+  notActivated: 'Inactive',
 };

--- a/packages/ringcentral-widgets/components/ContactDetails/index.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/index.js
@@ -19,54 +19,73 @@ export function getPresenceStatusName(presence, currentLocale) {
 }
 
 function AvatarNode({ name, avatarUrl }) {
-  return avatarUrl ?
-    (
-      <img
-        className={styles.avatarNode}
-        alt={name}
-        src={avatarUrl}
-      />
-    ) :
-    (
-      <DefaultAvatar
-        className={styles.avatarNode}
-      />
-    );
+  return avatarUrl ? (
+    <img className={styles.avatarNode} alt={name} src={avatarUrl} />
+  ) : (
+    <DefaultAvatar className={styles.avatarNode} />
+  );
 }
 AvatarNode.propTypes = {
   name: PropTypes.string,
-  avatarUrl: PropTypes.string,
+  avatarUrl: PropTypes.string
 };
 AvatarNode.defaultProps = {
   name: undefined,
-  avatarUrl: undefined,
+  avatarUrl: undefined
 };
 
 export default class ContactDetails extends PureComponent {
   onClickToDial = (contact, phoneNumber) => {
     this.props.onClickToDial({
       ...contact,
-      phoneNumber,
+      phoneNumber
     });
-  }
+  };
 
   onClickToSMS = (contact, phoneNumber) => {
     this.props.onClickToSMS({
       ...contact,
       phoneNumber
     });
-  }
+  };
 
   onClickMailTo = (email, contactType) => {
     if (typeof this.props.onClickMailTo === 'function') {
       this.props.onClickMailTo(email, contactType);
     }
-  }
+  };
+
+  renderPresence = (contactStatus, presence, presenceName, currentLocale) => {
+    if (contactStatus === 'NotActivated') {
+      return (
+        <div className={styles.presence}>
+          <div>
+            <span className={styles.inactiveText}>
+              {i18n.getString('notActivated', currentLocale)}
+            </span>
+          </div>
+        </div>
+      );
+    }
+
+    return presence ? (
+      <div className={styles.presence}>
+        <div className={styles.presenceNodeContainer}>
+          <PresenceStatusIcon className={styles.presenceNode} {...presence} />
+        </div>
+        <span className={styles.presenceStatus}>{presenceName}</span>
+      </div>
+    ) : null;
+  };
 
   renderProfile() {
     const { contactItem, sourceNodeRenderer, currentLocale } = this.props;
     const {
-      name, presence, profileImageUrl, type
+      name,
+      presence,
+      profileImageUrl,
+      type,
+      contactStatus
     } = contactItem;
     const sourceNode = sourceNodeRenderer({ sourceType: type });
     const presenceName = presence
@@ -76,40 +95,27 @@ export default class ContactDetails extends PureComponent {
       <div className={styles.contactProfile}>
         <div className={styles.avatar}>
           <div className={styles.avatarNodeContainer}>
-            <AvatarNode
-              name={name}
-              avatarUrl={profileImageUrl}
-            />
-            {
-              sourceNode
-                ? (
-                  <div className={styles.sourceNodeContainer}>
-                    {sourceNode}
-                  </div>
-                ) : null
-            }
+            <AvatarNode name={name} avatarUrl={profileImageUrl} />
+            {sourceNode ? (
+              <div className={styles.sourceNodeContainer}>{sourceNode}</div>
+            ) : null}
           </div>
         </div>
         <div className={styles.info}>
-          <div className={classnames(styles.name, !presence ? styles.nameWithoutPresence : null)}>
-            <span title={name}>{name}</span>
+          <div
+            className={classnames(
+              styles.name,
+              !presence ? styles.nameWithoutPresence : null
+            )}
+          >
+            <span style={contactStatus === 'NotActivated' ? { color: '#999999', fontSize: '12px' } : null} title={name}>{name}</span>
           </div>
-          {
-            presence
-              ? (
-                <div className={styles.presence}>
-                  <div className={styles.presenceNodeContainer}>
-                    <PresenceStatusIcon
-                      className={styles.presenceNode}
-                      {...presence}
-                    />
-                  </div>
-                  <span className={styles.presenceStatus}>
-                    {presenceName}
-                  </span>
-                </div>
-              ) : null
-          }
+          {this.renderPresence(
+            contactStatus,
+            presence,
+            presenceName,
+            currentLocale
+          )}
         </div>
       </div>
     );
@@ -120,9 +126,13 @@ export default class ContactDetails extends PureComponent {
     const { extensionNumber } = contactItem;
     if (!extensionNumber) return null;
     const textBtn = this.props.internalSmsPermission ? (
-      <button title={i18n.getString('text', currentLocale)} onClick={() => this.onClickToSMS(contactItem, extensionNumber)}>
+      <button
+        title={i18n.getString('text', currentLocale)}
+        onClick={() => this.onClickToSMS(contactItem, extensionNumber)}
+      >
         <i className={dynamicsFont.composeText} />
-      </button>) : null;
+      </button>
+    ) : null;
     const callBtn = this.props.onClickToDial ? (
       <button
         title={i18n.getString('call', currentLocale)}
@@ -134,7 +144,7 @@ export default class ContactDetails extends PureComponent {
     return (
       <div className={styles.item}>
         <div className={styles.label}>
-          <span>{ i18n.getString('extensionLabel', currentLocale) }</span>
+          <span>{i18n.getString('extensionLabel', currentLocale)}</span>
         </div>
         <ul>
           <li>
@@ -154,47 +164,46 @@ export default class ContactDetails extends PureComponent {
   renderDirectNumberCell() {
     const { contactItem, currentLocale } = this.props;
     const { phoneNumbers } = contactItem;
-    const phoneNumberListView = phoneNumbers.map(({ phoneType, phoneNumber }, index) => {
-      if (phoneType === 'extension') return null;
-      const formattedPhoneNumber = this.props.formatNumber(phoneNumber);
-      const textBtn = this.props.outboundSmsPermission ? (
-        <button title={i18n.getString('text', currentLocale)} onClick={() => this.onClickToSMS(contactItem, phoneNumber)}>
-          <i className={dynamicsFont.composeText} />
-        </button>) : null;
-      const callBtn = this.props.onClickToDial ? (
-        <button
-          title={i18n.getString('call', currentLocale)}
-          onClick={() => this.onClickToDial(contactItem, phoneNumber)}
-        >
-          <i className={dynamicsFont.call} />
-        </button>
-      ) : null;
-      return (
-        <li key={index}>
-          <div className={styles.number}>
-            <span title={formattedPhoneNumber}>{formattedPhoneNumber}</span>
-          </div>
-          <div className={styles.menu}>
-            {callBtn}
-            {textBtn}
-            {
-              // <button>
-              //   <FaxIcon className={styles.faxIcon} />
-              // </button>
-            }
-          </div>
-        </li>
-      );
-    }).filter(v => !!v);
+    const phoneNumberListView = phoneNumbers
+      .map(({ phoneType, phoneNumber }, index) => {
+        if (phoneType === 'extension') return null;
+        const formattedPhoneNumber = this.props.formatNumber(phoneNumber);
+        const textBtn = this.props.outboundSmsPermission ? (
+          <button
+            title={i18n.getString('text', currentLocale)}
+            onClick={() => this.onClickToSMS(contactItem, phoneNumber)}
+          >
+            <i className={dynamicsFont.composeText} />
+          </button>
+        ) : null;
+        const callBtn = this.props.onClickToDial ? (
+          <button
+            title={i18n.getString('call', currentLocale)}
+            onClick={() => this.onClickToDial(contactItem, phoneNumber)}
+          >
+            <i className={dynamicsFont.call} />
+          </button>
+        ) : null;
+        return (
+          <li key={index}>
+            <div className={styles.number}>
+              <span title={formattedPhoneNumber}>{formattedPhoneNumber}</span>
+            </div>
+            <div className={styles.menu}>
+              {callBtn}
+              {textBtn}
+            </div>
+          </li>
+        );
+      })
+      .filter(v => !!v);
     if (phoneNumberListView.length <= 0) return null;
     return (
       <div className={styles.item}>
         <div className={styles.label}>
           <span>{i18n.getString('directLabel', currentLocale)}</span>
         </div>
-        <ul>
-          {phoneNumberListView}
-        </ul>
+        <ul>{phoneNumberListView}</ul>
       </div>
     );
   }
@@ -230,21 +239,14 @@ export default class ContactDetails extends PureComponent {
     const directNumberCellView = this.renderDirectNumberCell();
     return (
       <div className={styles.root}>
-        <div className={styles.profile}>
-          {this.renderProfile()}
-        </div>
-        {
-          extensionCellView || directNumberCellView
-            ? (
-              <div className={styles.contacts}>
-                {extensionCellView}
-                {directNumberCellView}
-              </div>
-            ) : null
-        }
-        <div className={styles.email}>
-          {this.renderEmailCell()}
-        </div>
+        <div className={styles.profile}>{this.renderProfile()}</div>
+        {extensionCellView || directNumberCellView ? (
+          <div className={styles.contacts}>
+            {extensionCellView}
+            {directNumberCellView}
+          </div>
+        ) : null}
+        <div className={styles.email}>{this.renderEmailCell()}</div>
       </div>
     );
   }
@@ -257,10 +259,13 @@ export const contactItemPropTypes = {
   lastName: PropTypes.string,
   email: PropTypes.string,
   profileImageUrl: PropTypes.string,
-  phoneNumbers: PropTypes.arrayOf(PropTypes.shape({
-    phoneNumber: PropTypes.string,
-    phoneType: PropTypes.string,
-  })),
+  phoneNumbers: PropTypes.arrayOf(
+    PropTypes.shape({
+      phoneNumber: PropTypes.string,
+      phoneType: PropTypes.string
+    })
+  ),
+  contactStatus: PropTypes.string
 };
 
 ContactDetails.propTypes = {
@@ -272,7 +277,7 @@ ContactDetails.propTypes = {
   onClickMailTo: PropTypes.func,
   formatNumber: PropTypes.func.isRequired,
   outboundSmsPermission: PropTypes.bool,
-  internalSmsPermission: PropTypes.bool,
+  internalSmsPermission: PropTypes.bool
 };
 
 ContactDetails.defaultProps = {
@@ -281,5 +286,5 @@ ContactDetails.defaultProps = {
   onClickMailTo: undefined,
   sourceNodeRenderer: () => null,
   outboundSmsPermission: false,
-  internalSmsPermission: false,
+  internalSmsPermission: false
 };

--- a/packages/ringcentral-widgets/components/ContactDetails/styles.scss
+++ b/packages/ringcentral-widgets/components/ContactDetails/styles.scss
@@ -1,14 +1,16 @@
-@import '../../lib/commonStyles/layout.scss';
-@import '../../lib/commonStyles/reset.scss';
-@import '../../lib/commonStyles/colors.scss';
-@import '../../lib/commonStyles/fonts.scss';
-@import '../../lib/commonStyles/text-ellipsis';
+@import "../../lib/commonStyles/layout.scss";
+@import "../../lib/commonStyles/reset.scss";
+@import "../../lib/commonStyles/colors.scss";
+@import "../../lib/commonStyles/fonts.scss";
+@import "../../lib/commonStyles/text-ellipsis";
 
 .root {
   padding: 0 15px;
 }
 
-.profile, .contacts, .email {
+.profile,
+.contacts,
+.email {
   padding: 20px 0;
 }
 .profile {
@@ -41,10 +43,12 @@
     list-style: none;
     width: 80%;
   }
-  li:not(:first-child){
+  li:not(:first-child) {
     margin-top: 20px;
   }
-  .label, .number, .menu {
+  .label,
+  .number,
+  .menu {
     display: inline-block;
   }
   .label {
@@ -213,7 +217,10 @@ $rowHeight: 50px;
       @include secondary-font;
       @include text-ellipsis;
     }
-    a, a:hover, a:visited, a:focus {
+    a,
+    a:hover,
+    a:visited,
+    a:focus {
       color: $primary-color;
     }
   }
@@ -223,3 +230,7 @@ $rowHeight: 50px;
   }
 }
 
+.inactiveText {
+  font-size: $tertiary-font-size;
+  color: $coin;
+}

--- a/packages/ringcentral-widgets/components/ContactItem/i18n/en-US.js
+++ b/packages/ringcentral-widgets/components/ContactItem/i18n/en-US.js
@@ -1,0 +1,3 @@
+export default {
+  notActivated: 'Inactive',
+};

--- a/packages/ringcentral-widgets/components/ContactItem/i18n/index.js
+++ b/packages/ringcentral-widgets/components/ContactItem/i18n/index.js
@@ -1,0 +1,4 @@
+import I18n from '@ringcentral-integration/i18n';
+import loadLocale from './loadLocale';
+
+export default new I18n(loadLocale);

--- a/packages/ringcentral-widgets/components/ContactItem/i18n/loadLocale.js
+++ b/packages/ringcentral-widgets/components/ContactItem/i18n/loadLocale.js
@@ -1,0 +1,1 @@
+/* loadLocale */

--- a/packages/ringcentral-widgets/components/ContactItem/index.js
+++ b/packages/ringcentral-widgets/components/ContactItem/index.js
@@ -3,38 +3,31 @@ import PropTypes from 'prop-types';
 
 import PresenceStatusIcon from '../PresenceStatusIcon';
 import DefaultAvatar from '../../assets/images/DefaultAvatar.svg';
+import i18n from './i18n';
 
 import styles from './styles.scss';
 
 function AvatarNode({ name, avatarUrl }) {
-  return avatarUrl ?
-    (
-      <img
-        className={styles.avatarNode}
-        alt={name}
-        src={avatarUrl}
-      />
-    ) :
-    (
-      <DefaultAvatar
-        className={styles.avatarNode}
-      />
-    );
+  return avatarUrl ? (
+    <img className={styles.avatarNode} alt={name} src={avatarUrl} />
+  ) : (
+    <DefaultAvatar className={styles.avatarNode} />
+  );
 }
 AvatarNode.propTypes = {
   name: PropTypes.string,
-  avatarUrl: PropTypes.string,
+  avatarUrl: PropTypes.string
 };
 AvatarNode.defaultProps = {
   name: undefined,
-  avatarUrl: undefined,
+  avatarUrl: undefined
 };
 
 export default class ContactItem extends PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      loading: true,
+      loading: true
     };
     this.onItemSelected = this.onItemSelected.bind(this);
   }
@@ -44,7 +37,7 @@ export default class ContactItem extends PureComponent {
     this._loadingTimeout = setTimeout(() => {
       if (this._mounted) {
         this.setState({
-          loading: false,
+          loading: false
         });
       }
     }, 3);
@@ -70,57 +63,67 @@ export default class ContactItem extends PureComponent {
     }
   }
 
-  render() {
-    if (this.state.loading) {
+  renderPresence = (contact) => {
+    const { presence, contactStatus } = contact;
+    if (contactStatus === 'NotActivated') {
+      return null;
+    }
+
+    return presence ? (
+      <div className={styles.presenceNodeContainer}>
+        <PresenceStatusIcon className={styles.presenceNode} {...presence} />
+      </div>
+    ) : null;
+  };
+
+  renderMiddle = (contact, currentLocale) => {
+    const { name, contactStatus } = contact;
+    if (contactStatus === 'NotActivated') {
       return (
-        <div className={styles.root} />
+        <div className={styles.infoWrapper}>
+          <div className={styles.inactiveContactName} title={name}>
+            {name}
+          </div>
+          <div className={styles.inactiveText}>
+            {i18n.getString('notActivated', currentLocale)}
+          </div>
+        </div>
       );
     }
+
+    return (
+      <div className={styles.contactName} title={name}>
+        {name}
+      </div>
+    );
+  };
+
+  render() {
+    if (this.state.loading) {
+      return <div className={styles.root} />;
+    }
     const {
-      name,
-      extensionNumber,
-      type,
-      profileImageUrl,
-      presence,
-    } = this.props.contact;
+      contact,
+      currentLocale
+    } = this.props;
+    const {
+      name, extensionNumber, type, profileImageUrl
+    } = contact;
 
     const { sourceNodeRenderer } = this.props;
     const sourceNode = sourceNodeRenderer({ sourceType: type });
     return (
-      <div
-        className={styles.root}
-        onClick={this.onItemSelected}
-      >
+      <div className={styles.root} onClick={this.onItemSelected}>
         <div className={styles.contactProfile}>
           <div className={styles.avatarNodeContainer}>
-            <AvatarNode
-              name={name}
-              avatarUrl={profileImageUrl}
-            />
+            <AvatarNode name={name} avatarUrl={profileImageUrl} />
           </div>
-          {
-            sourceNode
-              ? (
-                <div className={styles.sourceNodeContainer}>
-                  {sourceNode}
-                </div>
-              )
-              : null
-          }
-          {
-            presence ? (
-              <div className={styles.presenceNodeContainer}>
-                <PresenceStatusIcon
-                  className={styles.presenceNode}
-                  {...presence}
-                />
-              </div>
-            ) : null
-          }
+          {sourceNode ? (
+            <div className={styles.sourceNodeContainer}>{sourceNode}</div>
+          ) : null}
+          {this.renderPresence(this.props.contact)}
         </div>
-        <div className={styles.contactName} title={name}>
-          {name}
-        </div>
+        {this.renderMiddle(contact, currentLocale)}
         <div className={styles.phoneNumber} title={extensionNumber}>
           {extensionNumber}
         </div>
@@ -130,6 +133,7 @@ export default class ContactItem extends PureComponent {
 }
 
 ContactItem.propTypes = {
+  currentLocale: PropTypes.string.isRequired,
   contact: PropTypes.shape({
     id: PropTypes.string,
     type: PropTypes.string,
@@ -138,14 +142,15 @@ ContactItem.propTypes = {
     email: PropTypes.string,
     profileImageUrl: PropTypes.string,
     presence: PropTypes.object,
+    contactStatus: PropTypes.string
   }).isRequired,
   getAvatarUrl: PropTypes.func.isRequired,
   getPresence: PropTypes.func.isRequired,
   onSelect: PropTypes.func,
-  sourceNodeRenderer: PropTypes.func,
+  sourceNodeRenderer: PropTypes.func
 };
 
 ContactItem.defaultProps = {
   onSelect: undefined,
-  sourceNodeRenderer: () => null,
+  sourceNodeRenderer: () => null
 };

--- a/packages/ringcentral-widgets/components/ContactItem/styles.scss
+++ b/packages/ringcentral-widgets/components/ContactItem/styles.scss
@@ -1,6 +1,6 @@
-@import '../../lib/commonStyles/colors.scss';
-@import '../../lib/commonStyles/fonts.scss';
-@import '../../lib/commonStyles/reset.scss';
+@import "../../lib/commonStyles/colors.scss";
+@import "../../lib/commonStyles/fonts.scss";
+@import "../../lib/commonStyles/reset.scss";
 
 $rowHeight: 50px;
 
@@ -32,7 +32,7 @@ $rowHeight: 50px;
 }
 
 .contactName {
-  @include secondary-font;
+  @include second-primary-font;
   float: left;
   padding-left: 6px;
   padding-right: 6px;
@@ -86,7 +86,6 @@ $rowHeight: 50px;
   border-radius: 7px;
   top: 6px;
   right: 2px;
-
 }
 
 .presenceNodeContainer {
@@ -110,4 +109,41 @@ $rowHeight: 50px;
       left: -1px;
     }
   }
+}
+
+.infoWrapper {
+  float: left;
+  max-width: 60%;
+  height: $rowHeight;
+  line-height: $rowHeight;
+}
+
+.inactiveContactName {
+  @include second-primary-font;
+  color: $coin;
+  margin-top: 10px;
+  line-height: normal;
+  float: left;
+  padding-left: 6px;
+  padding-right: 6px;
+  text-align: left;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.inactiveText {
+  font-size: $tertiary-font-size;
+  color: $coin;
+  margin-top: 2px;
+  line-height: normal;
+  float: left;
+  padding-left: 6px;
+  padding-right: 6px;
+  text-align: left;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: 100%;
 }

--- a/packages/ringcentral-widgets/components/ContactList/index.js
+++ b/packages/ringcentral-widgets/components/ContactList/index.js
@@ -116,6 +116,7 @@ export default class ContactList extends Component {
       );
     }
     const {
+      currentLocale,
       getAvatarUrl,
       getPresence,
       onItemSelect,
@@ -126,6 +127,7 @@ export default class ContactList extends Component {
         key={`${rowData.type}-${rowData.id}`}
       >
         <ContactItem
+          currentLocale={currentLocale}
           contact={rowData}
           getAvatarUrl={getAvatarUrl}
           getPresence={getPresence}

--- a/packages/ringcentral-widgets/components/RecentActivityPanel/styles.scss
+++ b/packages/ringcentral-widgets/components/RecentActivityPanel/styles.scss
@@ -1,4 +1,4 @@
-@import '../../lib/commonStyles/fonts.scss';
+@import "../../lib/commonStyles/fonts.scss";
 
 .container {
   width: 100%;
@@ -12,7 +12,7 @@
   cursor: pointer;
   border-color: #e3e3e3;
   @include primary-font;
-  font-weight: 300;
+  font-weight: normal;
   font-size: 15px;
 }
 

--- a/packages/ringcentral-widgets/lib/commonStyles/fonts.scss
+++ b/packages/ringcentral-widgets/lib/commonStyles/fonts.scss
@@ -1,4 +1,4 @@
-@import 'colors';
+@import "colors";
 $font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 $primary-font-size: 14px;
 $secondary-font-size: 13px;
@@ -7,6 +7,12 @@ $tertiary-font-size: 12px;
 @mixin primary-font {
   font-family: $font-family;
   font-size: $primary-font-size;
+  color: $primary-neutral-color;
+}
+
+@mixin second-primary-font {
+  font-family: $font-family;
+  font-size: $secondary-font-size;
   color: $primary-neutral-color;
 }
 


### PR DESCRIPTION
1. Users who are not activated add a new status to highlight this status in both `Contact Item` and `Contact Detail` pages.
2. In order to do this,  a contact's `NotActivated` status is added in this contact's model. `AccountExtension` and `AccountContacts`'s filter has been modified to not filter this status.
3. Related `i18n` files have been added in `ContactItem` directory.