### PR TITLE
refactor(DialerAndCallsTabContainer): judge `applicable` by callMonitor

### DIFF
--- a/packages/ringcentral-widgets/containers/DialerAndCallsTabContainer/index.js
+++ b/packages/ringcentral-widgets/containers/DialerAndCallsTabContainer/index.js
@@ -56,12 +56,12 @@ function mapToProps(_, {
     callingSettings,
     routerInteraction,
     conferenceCall,
-    webphone,
+    callMonitor,
   },
 }) {
   const conferenceCallEquipped = !!conferenceCall;
   const isWebphoneMode = (callingSettings.callingMode === callingModes.webphone);
-  const applicable = !!(conferenceCallEquipped && isWebphoneMode && webphone.sessions.length);
+  const applicable = !!(conferenceCallEquipped && isWebphoneMode && callMonitor.calls.length);
   return {
     applicable,
     currentLocale: locale.currentLocale,


### PR DESCRIPTION
Since we showing the call items in all calls page by presence API, then we should show tabs by the same design