### PR TITLE
fix(Webphone): fix the :bug: when double-click on answer button in coming page, it won't navigate to call control page

### DIFF
--- a/packages/ringcentral-integration/modules/Webphone/index.js
+++ b/packages/ringcentral-integration/modules/Webphone/index.js
@@ -746,7 +746,7 @@ export default class Webphone extends RcModule {
       console.error(e);
       if (e.code !== INCOMING_CALL_INVALID_STATE_ERROR_CODE) {
         // FIXME:
-        // 2 means the call is answered.
+        // 2 means the call is answered
         this._onCallEnd(sipSession);
       }
     }

--- a/packages/ringcentral-widgets-demo/dev-server/Phone.js
+++ b/packages/ringcentral-widgets-demo/dev-server/Phone.js
@@ -292,11 +292,7 @@ export default class BasePhone extends RcModule {
     });
 
     webphone.onCallStart(() => {
-      if (
-        routerInteraction.currentPath.indexOf('/calls/active') !== 0
-      ) {
-        routerInteraction.push('/calls/active');
-      }
+      routerInteraction.push('/calls/active');
     });
 
     webphone.onCallRing(() => {


### PR DESCRIPTION
* Handle the answer method to avoid duplicate Accepting call actions which leads an error that can end the call

* Related work item: #RCINT-8631
