### PR TITLE
fix(IncomingCallPage): fix state change

### DIFF
--- a/packages/ringcentral-integration/modules/Webphone/getWebphoneReducer.js
+++ b/packages/ringcentral-integration/modules/Webphone/getWebphoneReducer.js
@@ -2,7 +2,7 @@ import { combineReducers } from 'redux';
 import getModuleStatusReducer from '../../lib/getModuleStatusReducer';
 import connectionStatus from './connectionStatus';
 import sessionStatus from './sessionStatus';
-import { isRing, sortByLastActiveTimeDesc } from './webphoneHelper';
+import { isInbound, isRing, sortByLastActiveTimeDesc } from './webphoneHelper';
 
 export function getVideoElementPreparedReducer(types) {
   return (state = false, { type }) => {
@@ -78,6 +78,10 @@ export function getActiveSessionIdReducer(types) {
   return (state = null, { type, session = {}, sessions = [] }) => {
     switch (type) {
       case types.beforeCallStart:
+        if (!isInbound(session)) {
+          return session.id;
+        }
+        return state;
       case types.callStart:
         return session.id;
       case types.callEnd: {
@@ -106,7 +110,7 @@ export function getRingSessionIdReducer(types) {
     switch (type) {
       case types.callRing:
         return session.id;
-      case types.beforeCallStart:
+      // case types.beforeCallStart:
       case types.callStart:
       case types.callEnd:
         if (session.id !== state) {

--- a/packages/ringcentral-integration/modules/Webphone/index.js
+++ b/packages/ringcentral-integration/modules/Webphone/index.js
@@ -737,7 +737,7 @@ export default class Webphone extends RcModule {
       this._onAccepted(sipSession, 'inbound');
       this._beforeCallStart(sipSession);
       await sipSession.accept(this.acceptOptions);
-      this._onCallStart(sipSession);
+      // this._onCallStart(sipSession);
       this.store.dispatch({ // for track
         type: this.actionTypes.callAnswer,
       });

--- a/packages/ringcentral-integration/modules/Webphone/webphoneHelper.js
+++ b/packages/ringcentral-integration/modules/Webphone/webphoneHelper.js
@@ -95,6 +95,14 @@ export function isRing(session) {
   );
 }
 
+
+export function isInbound(session) {
+  return !!(
+    session &&
+    session.direction === callDirections.inbound
+  );
+}
+
 export function isOnHold(session) {
   return !!(session && session.callStatus === sessionStatus.onHold);
 }

--- a/packages/ringcentral-widgets-demo/dev-server/Phone.js
+++ b/packages/ringcentral-widgets-demo/dev-server/Phone.js
@@ -294,6 +294,9 @@ export default class BasePhone extends RcModule {
     });
 
     webphone.onCallStart(() => {
+      if (routerInteraction.currentPath === '/calls/active') {
+        return;
+      }
       routerInteraction.push('/calls/active');
     });
 

--- a/packages/ringcentral-widgets/containers/IncomingCallPage/index.js
+++ b/packages/ringcentral-widgets/containers/IncomingCallPage/index.js
@@ -69,11 +69,9 @@ class IncomingCallPage extends Component {
       this._updateAvatarAndMatchIndex(nextProps);
     }
     // if we just pick up the phone, and the modal is still opening, then do nothing at all
-    if (nextProps.activeSessionId !== nextProps.session.id) {
-      this.setState({
-        hasOtherActiveCall: !!nextProps.activeSessionId,
-      });
-    }
+    this.setState({
+      hasOtherActiveCall: !!nextProps.activeSessionId,
+    });
   }
 
   componentWillUnmount() {

--- a/packages/ringcentral-widgets/containers/IncomingCallPage/index.js
+++ b/packages/ringcentral-widgets/containers/IncomingCallPage/index.js
@@ -68,13 +68,12 @@ class IncomingCallPage extends Component {
     if (this.props.session.id !== nextProps.session.id) {
       this._updateAvatarAndMatchIndex(nextProps);
     }
-    this.setState({
-      hasOtherActiveCall: nextProps.activeSessionId
-        // when ringcall became active call
-        ? nextProps.activeSessionId !== nextProps.session.id
-        // otherwise when no active call
-        : false,
-    });
+    // if we just pick up the phone, and the modal is still opening, then do nothing at all
+    if (nextProps.activeSessionId !== nextProps.session.id) {
+      this.setState({
+        hasOtherActiveCall: !!nextProps.activeSessionId,
+      });
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
When we just picking up an incoming call, and while the modal is still opening, the state
`hasOtherActiveCall` will be set to false because `nextProps.activeSessionId ===
nextProps.session.id, we need to avoid this`