### PR TITLE
fix(CallCtrlPage, CallMonitor): 🐛 fix a bug in onAdd method in CallCtrlPage

### DIFF
--- a/packages/ringcentral-integration/modules/CallMonitor/index.js
+++ b/packages/ringcentral-integration/modules/CallMonitor/index.js
@@ -554,6 +554,10 @@ export default class CallMonitor extends RcModule {
     return this._selectors.calls();
   }
 
+  get allCalls() {
+    return this._selectors.allCalls();
+  }
+
   get callMatched() {
     return this._storage.getItem(this._callMatchedKey);
   }

--- a/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
+++ b/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
@@ -199,7 +199,7 @@ function mapToFunctions(_, {
       if (!session || webphone.isCallRecording({ session })) {
         return;
       }
-      const outBoundOnholdCalls = filter(
+      const otherOutboundCalls = filter(
         call => call.direction === callDirections.outbound &&
                 (
                   call.webphoneSession &&
@@ -207,7 +207,7 @@ function mapToFunctions(_, {
                 ),
         callMonitor.allCalls
       );
-      if (outBoundOnholdCalls.length) {
+      if (otherOutboundCalls.length) {
         // goto 'calls on hold' page
         routerInteraction.push(`/conferenceCall/callsOnhold/${session.fromNumber}/${session.id}`);
       } else {

--- a/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
+++ b/packages/ringcentral-widgets/containers/CallCtrlPage/index.js
@@ -200,8 +200,12 @@ function mapToFunctions(_, {
         return;
       }
       const outBoundOnholdCalls = filter(
-        call => call.direction === callDirections.outbound,
-        callMonitor.activeOnHoldCalls
+        call => call.direction === callDirections.outbound &&
+                (
+                  call.webphoneSession &&
+                  call.webphoneSession.id !== session.id
+                ),
+        callMonitor.allCalls
       );
       if (outBoundOnholdCalls.length) {
         // goto 'calls on hold' page


### PR DESCRIPTION
* Refine the logic onAdd method in CallCtrlPage

#RCINT-8649 (Given 1 hold call and 1 active incoming call, when clicking the Add button from the on-hold call ctrl page, it will not redirect to the simplified call ctrl dialer page)

