### PR TITLE
fix(CallCtrlPage/helper.js, callHelper): Session do not have callId in getInboundCall

### DIFF
--- a/packages/ringcentral-widgets-test/test/integration-test/CallCtrlPage/ConferenceCallCtrl.spec.js
+++ b/packages/ringcentral-widgets-test/test/integration-test/CallCtrlPage/ConferenceCallCtrl.spec.js
@@ -51,11 +51,13 @@ describe('RCI-1710786 Conference Call Control Page - Mute/Muted', () => {
     wrapper.update();
     muteButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(0);
     muteButton.find(CircleButton).simulate('click');
+    await timeout(100);
     wrapper.update();
     muteButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(0);
     expect(muteButton.find('.buttonTitle').text()).toEqual('Unmute');
     expect(muteFn.mock.calls[0]).toEqual([conferenceSession.id]);
     muteButton.find(CircleButton).simulate('click');
+    await timeout(100);
     wrapper.update();
     muteButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(0);
     expect(muteButton.find('.buttonTitle').text()).toEqual('Mute');
@@ -81,6 +83,7 @@ describe('RCI-1710773 Conference Call Control Page - Hold/Unhold', () => {
     // Click Hold Button
     holdButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(2);
     holdButton.find(CircleButton).simulate('click');
+    await timeout(100);
     wrapper.update();
     muteButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(0);
     holdButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(2);
@@ -91,6 +94,7 @@ describe('RCI-1710773 Conference Call Control Page - Hold/Unhold', () => {
     expect(recordButton.props().disabled).toBe(true);
     // Unhold button
     holdButton.find(CircleButton).simulate('click');
+    await timeout(100);
     wrapper.update();
     muteButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(0);
     holdButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(2);
@@ -110,6 +114,7 @@ describe('RCI-2980793 Conference Call Control Page - Hang Up', () => {
     const handupButton = wrapper.find('.stopButtonGroup').find(CircleButton);
     expect(handupButton.props().className).toEqual('stopButton');
     handupButton.find(CircleButton).simulate('click');
+    await timeout(100);
     expect(phone.webphone.sessions).toHaveLength(0);
     expect(phone.routerInteraction.currentPath).toEqual('/dialer');
   });
@@ -122,6 +127,7 @@ describe('RCI-2980793 Conference Call Control Page - Hang Up', () => {
     const handupButton = wrapper.find('.stopButtonGroup').find(CircleButton);
     expect(handupButton.props().className).toEqual('stopButton');
     handupButton.find(CircleButton).simulate('click');
+    await timeout(100);
     expect(phone.webphone.sessions).toHaveLength(1);
     expect(phone.routerInteraction.currentPath).toEqual('/calls/active');
   });
@@ -138,14 +144,14 @@ describe('Conference Call Control Page - Record/Stop', () => {
       expect(recordButton.find('.buttonTitle').text()).toEqual('Record');
 
       recordButton.find(CircleButton).simulate('click');
-      await timeout(200);
+      await timeout(100);
       wrapper.update();
       recordButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(4);
       expect(recordButton.find('.buttonTitle').text()).toEqual('Stop');
       expect(startRecordFn.mock.calls[0]).toEqual([conferenceSession.id]);
 
       recordButton.find(CircleButton).simulate('click');
-      await timeout(200);
+      await timeout(100);
       recordButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(4);
       expect(recordButton.find('.buttonTitle').text()).toEqual('Record');
       expect(stopRecordFn.mock.calls[0]).toEqual([conferenceSession.id]);
@@ -162,8 +168,9 @@ describe('Conference Call Control Page - Add', () => {
     recordButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(4);
     const addButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(3);
     recordButton.find(CircleButton).simulate('click');
-    await timeout(200);
+    await timeout(100);
     addButton.find(CircleButton).simulate('click');
+    await timeout(100);
     const store = wrapper.props().phone.store;
     const messages = store.getState(wrapper).alert.messages;
     expect(messages).toEqual(
@@ -188,7 +195,9 @@ describe('Conference Call Control Page - Merge Button', () => {
     recordButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(4);
     const mergeButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(3);
     recordButton.find(CircleButton).simulate('click');
+    await timeout(100);
     mergeButton.find(CircleButton).simulate('click');
+    await timeout(100);
     const store = wrapper.props().phone.store;
     const messages = store.getState(wrapper).alert.messages;
     expect(messages).toEqual(

--- a/packages/ringcentral-widgets-test/test/integration-test/CallCtrlPage/helper.js
+++ b/packages/ringcentral-widgets-test/test/integration-test/CallCtrlPage/helper.js
@@ -17,7 +17,9 @@ import { timeout } from '../shared';
 
 export async function makeOutboundCall(phone) {
   mock.device(deviceBody);
-  phone.webphone.sessions.forEach(session => phone.webphone.hold(session.id));
+  phone.webphone.sessions.forEach(async (session) => {
+    await phone.webphone.hold(session.id);
+  });
   const outboundSession = await makeCall(phone);
   return outboundSession;
 }
@@ -40,7 +42,9 @@ export async function updateConferenceCallEnv(phone, {
 export async function mockConferenceCallEnv(phone, params = {
   conferencePartiesCount: 3
 }) {
-  phone.webphone.sessions.forEach(session => phone.webphone.hold(session.id));
+  phone.webphone.sessions.forEach(async (session) => {
+    await phone.webphone.hold(session.id);
+  });
   const conferenceBodyData = getConferenceCallBody(params.conferencePartiesCount);
   /* mock data */
   mock.device(deviceBody);

--- a/packages/ringcentral-widgets-test/test/integration-test/CallCtrlPage/helper.js
+++ b/packages/ringcentral-widgets-test/test/integration-test/CallCtrlPage/helper.js
@@ -17,9 +17,9 @@ import { timeout } from '../shared';
 
 export async function makeOutboundCall(phone) {
   mock.device(deviceBody);
-  phone.webphone.sessions.forEach(async (session) => {
+  for (const session of phone.webphone.sessions) {
     await phone.webphone.hold(session.id);
-  });
+  }
   const outboundSession = await makeCall(phone);
   return outboundSession;
 }
@@ -42,9 +42,9 @@ export async function updateConferenceCallEnv(phone, {
 export async function mockConferenceCallEnv(phone, params = {
   conferencePartiesCount: 3
 }) {
-  phone.webphone.sessions.forEach(async (session) => {
+  for (const session of phone.webphone.sessions) {
     await phone.webphone.hold(session.id);
-  });
+  }
   const conferenceBodyData = getConferenceCallBody(params.conferencePartiesCount);
   /* mock data */
   mock.device(deviceBody);

--- a/packages/ringcentral-widgets-test/test/integration-test/ConferenceCall/flow.spec.js
+++ b/packages/ringcentral-widgets-test/test/integration-test/ConferenceCall/flow.spec.js
@@ -15,9 +15,6 @@ import { makeCall, mockActiveCalls, mockDetailedPresencePubnub, CONFERENCE_SESSI
 import { initPhoneWrapper, timeout } from '../shared';
 import deviceBody from './data/device';
 
-const wrapper = null;
-const phone = null;
-
 beforeEach(async () => {
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 64000;
 });
@@ -47,7 +44,7 @@ async function dialAnotherOutboundCall(phone, wrapper) {
   enterToNumber(domInput, '987654321');
   const callButton = wrapper.find(DialerPanel).find('.callBtn').first();
   callButton.find(CircleButton).simulate('click');
-  await timeout(10);
+  await timeout(100);
   /* pubnub push message */
   await updateCallMonitorCalls(phone);
   wrapper.update();
@@ -59,26 +56,31 @@ async function clickMergeButtonIn(wrapper, phone, pageName) {
   mock.conferenceCallBringIn(CONFERENCE_SESSION_ID);
   mock.device(deviceBody, false);
   mock.conferenceCall();
+  let confirmMergeButton = null;
   let mergeButton = null;
+  let callItem = null;
   /* click action */
   switch (pageName) {
     case 'OnholdPage':
       expect(wrapper.find(CallsOnholdPanel).find(ActiveCallItem)).toHaveLength(1);
-      const callItem = wrapper.find(CallsOnholdPanel).find(ActiveCallItem).first();
+      callItem = wrapper.find(CallsOnholdPanel).find(ActiveCallItem).first();
       mergeButton = callItem.find('.webphoneButton').first();
       mergeButton.find(CircleButton).simulate('click');
+      await timeout(100);
       break;
     case 'SimplifiedCallCtrlPage':
       mergeButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(3);
       mergeButton.find(CircleButton).simulate('click');
+      await timeout(100);
       break;
     case 'NormalCallCtrlPage':
       mergeButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(3);
       mergeButton.find(CircleButton).simulate('click');
-      await timeout(10);
+      await timeout(100);
       wrapper.update();
-      const confirmMergeButton = wrapper.find(ConfirmMergeModal).find(CircleButton);
+      confirmMergeButton = wrapper.find(ConfirmMergeModal).find(CircleButton);
       confirmMergeButton.simulate('click');
+      await timeout(100);
       break;
     default:
       console.error('pageName might be error');
@@ -109,7 +111,7 @@ describe('Merge Call Flow: Conference Call Ctrl -> click Merge -> on hold list',
     // Click Add
     const addButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(3);
     addButton.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     expect(phone.routerInteraction.currentPath.indexOf('/conferenceCall/callsOnhold')).toBe(0);
     // Click Merge
     await clickMergeButtonIn(wrapper, phone, 'OnholdPage');
@@ -127,14 +129,14 @@ describe('Merge Call Flow: Conference Call Ctrl -> click Merge -> on hold list',
     // Click Hold
     holdButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(2);
     holdButton.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
     holdButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(2);
     expect(holdButton.find('.buttonTitle').text()).toEqual('On Hold');
     // Click Add
     const addButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(3);
     addButton.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     expect(phone.routerInteraction.currentPath.indexOf('/conferenceCall/callsOnhold')).toBe(0);
     // Click Merge
     await clickMergeButtonIn(wrapper, phone, 'OnholdPage');
@@ -154,7 +156,7 @@ describe('Merge Call Flow: Conference Call Ctrl -> click Merge -> dialer', () =>
     // Click Add
     const addButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(3);
     addButton.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     expect(phone.routerInteraction.currentPath.indexOf('/conferenceCall/dialer')).toBe(0);
     // make another call
     await dialAnotherOutboundCall(phone, wrapper);
@@ -164,7 +166,7 @@ describe('Merge Call Flow: Conference Call Ctrl -> click Merge -> dialer', () =>
     // Click Hold
     holdButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(2);
     holdButton.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
     holdButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(2);
     expect(holdButton.find('.buttonTitle').text()).toEqual('On Hold');
@@ -183,7 +185,7 @@ describe('Merge Call Flow: Conference Call Ctrl -> click Merge -> dialer', () =>
     // Click Add
     const addButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(3);
     addButton.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     expect(phone.routerInteraction.currentPath.indexOf('/conferenceCall/dialer')).toBe(0);
     // make another call
     await dialAnotherOutboundCall(phone, wrapper);
@@ -210,7 +212,7 @@ describe('Merge Call Flow: Normal Call Ctrl -> click Merge -> popup', () => {
     // Click Hold
     holdButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(2);
     holdButton.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
     holdButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(2);
     expect(holdButton.find('.buttonTitle').text()).toEqual('On Hold');
@@ -245,7 +247,7 @@ describe('Add Call Flow: Normal Call Ctrl -> click Add -> dialer', () => {
     // Click Add
     const addButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(3);
     addButton.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     expect(phone.routerInteraction.currentPath.indexOf('/conferenceCall/dialer')).toBe(0);
     // make another call
     await dialAnotherOutboundCall(phone, wrapper);
@@ -267,7 +269,7 @@ describe('Add Call Flow: Normal Call Ctrl -> click Add -> dialer', () => {
     // Click Add
     const addButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(3);
     addButton.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     expect(phone.routerInteraction.currentPath.indexOf('/conferenceCall/dialer')).toBe(0);
     // make another call
     await dialAnotherOutboundCall(phone, wrapper);
@@ -277,7 +279,7 @@ describe('Add Call Flow: Normal Call Ctrl -> click Add -> dialer', () => {
     // Click Hold
     holdButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(2);
     holdButton.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
     holdButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(2);
     expect(holdButton.find('.buttonTitle').text()).toEqual('On Hold');
@@ -300,7 +302,7 @@ describe('Add Call Flow: Normal Call Ctrl -> click Add -> on hold list', () => {
     // Click Add
     const addButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(3);
     addButton.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     expect(phone.routerInteraction.currentPath.indexOf('/conferenceCall/callsOnhold')).toBe(0);
     // Click Merge
     await clickMergeButtonIn(wrapper, phone, 'OnholdPage');
@@ -319,14 +321,14 @@ describe('Add Call Flow: Normal Call Ctrl -> click Add -> on hold list', () => {
     // Click Hold
     holdButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(2);
     holdButton.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
     holdButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(2);
     expect(holdButton.find('.buttonTitle').text()).toEqual('On Hold');
     // Click Add
     const addButton = wrapper.find(ActiveCallPad).find(ActiveCallButton).at(3);
     addButton.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     expect(phone.routerInteraction.currentPath.indexOf('/conferenceCall/callsOnhold')).toBe(0);
     // Click Merge
     await clickMergeButtonIn(wrapper, phone, 'OnholdPage');

--- a/packages/ringcentral-widgets-test/test/integration-test/ConferenceCall/flow.spec.js
+++ b/packages/ringcentral-widgets-test/test/integration-test/ConferenceCall/flow.spec.js
@@ -39,7 +39,9 @@ async function dialAnotherOutboundCall(phone, wrapper) {
   /* mock data */
   mock.numberParser();
   mock.device(deviceBody);
-  phone.webphone.sessions.forEach(x => phone.webphone.hold(x.id));
+  phone.webphone.sessions.forEach(async (session) => {
+    await phone.webphone.hold(session.id);
+  });
   /* click action */
   const domInput = wrapper.find(DialerPanel).find(RecipientsInput).find('input');
   enterToNumber(domInput, '987654321');

--- a/packages/ringcentral-widgets-test/test/integration-test/ConferenceCall/flow.spec.js
+++ b/packages/ringcentral-widgets-test/test/integration-test/ConferenceCall/flow.spec.js
@@ -39,9 +39,9 @@ async function dialAnotherOutboundCall(phone, wrapper) {
   /* mock data */
   mock.numberParser();
   mock.device(deviceBody);
-  phone.webphone.sessions.forEach(async (session) => {
+  for (const session of phone.webphone.sessions) {
     await phone.webphone.hold(session.id);
-  });
+  }
   /* click action */
   const domInput = wrapper.find(DialerPanel).find(RecipientsInput).find('input');
   enterToNumber(domInput, '987654321');

--- a/packages/ringcentral-widgets-test/test/integration-test/ConferenceCallDialerPage/ActiveCallPanel.spec.js
+++ b/packages/ringcentral-widgets-test/test/integration-test/ConferenceCallDialerPage/ActiveCallPanel.spec.js
@@ -75,7 +75,6 @@ async function mockAddCall(phone, wrapper, contactA, contactB) {
     phoneNumber: contactA.phoneNumbers[0].phoneNumber
   });
   const sessionA = phone.webphone.sessions[0];
-  debugger;
   await phone.webphone.hold(sessionA.id);
   const callCtrlPage = wrapper.find(CallCtrlPage);
   await callCtrlPage.props().onAdd(sessionA.id);
@@ -130,7 +129,7 @@ describe('RCI-1071: simplified call control page #3', () => {
       await mockContacts(phone);
       const contactA = phone.contacts.allContacts.find(item => item.type === 'company' && item.hasProfileImage);
       await mockAddCall(phone, wrapper, contactA, contactA);
-      debugger;
+
       expect(phone.routerInteraction.currentPath).toEqual('/calls/active');
       await timeout(300);
       const mergeInfo = wrapper.find(MergeInfo);
@@ -152,7 +151,6 @@ describe('RCI-1071: simplified call control page #3', () => {
     await mockContacts(phone);
     const contactA = phone.contacts.allContacts.find(item => item.type === 'company' && item.hasProfileImage);
     await mockAddCall(phone, wrapper, contactA, contactA);
-    // debugger;
     const sessionId = phone.webphone.sessions[1].id;
     const sessionA = phone.webphone._sessions.get(sessionId);
     sessionA.terminate();

--- a/packages/ringcentral-widgets-test/test/integration-test/IncomingCallPage/IncomingCallPad.spec.js
+++ b/packages/ringcentral-widgets-test/test/integration-test/IncomingCallPage/IncomingCallPad.spec.js
@@ -36,7 +36,7 @@ async function makeInbountCall(phone, wrapper, sessionId) {
     id: sessionId,
     direction: 'Inbound'
   });
-  await timeout(10);
+  await timeout(100);
   wrapper.update();
 }
 
@@ -55,7 +55,7 @@ async function makeMultiCalls(phone, wrapper, firstCall) {
       .find(ActiveCallButton).at(4)
       .find(CircleButton)
       .simulate('click');
-    await timeout(10);
+    await timeout(100);
   } else {
     await makeOutboundCall(phone, wrapper);
   }
@@ -66,7 +66,7 @@ const enterToNumber = async (target, number) => {
   const domInput = target.find('input');
   domInput.instance().value = number;
   await domInput.simulate('change');
-  await timeout(10);
+  await timeout(100);
 };
 
 beforeEach(async () => {
@@ -107,7 +107,7 @@ describe('RCI-1038: There is no Add button', () => {
       .find(ActiveCallButton).at(4)
       .find(CircleButton)
       .simulate('click');
-    await timeout(10);
+    await timeout(100);
     await makeInbountCall(phone, wrapper, sid222);
     const page = wrapper.find(IncomingCallPad);
     const activeButtons = page.find(ActiveCallButton);
@@ -136,9 +136,8 @@ describe('To Voicemail Button', () => {
     expect(buttonToVoicemail.find('.buttonTitle').text()).toEqual('To Voicemail');
 
     buttonToVoicemail.find(CircleButton).simulate('click');
-    await timeout(10);
-    wrapper.update();
     await timeout(100);
+    wrapper.update();
     expect(rejectFn.mock.calls[0]).toContain(sid111);
     expect(toVoicemailFn.mock.calls[0]).toContain(sid111);
     expect(phone.webphone.sessions).toHaveLength(0);
@@ -156,7 +155,7 @@ describe('Check Answer Button', () => {
     expect(buttonAnswer.find('.buttonTitle').text()).toEqual('Answer');
 
     buttonAnswer.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     expect(acceptFn.mock.calls[0]).toContain(sid111);
     expect(phone.webphone.sessions).toHaveLength(1);
     expect(phone.webphone.sessions[0].callStatus).toEqual(sessionStatus.connected);
@@ -177,7 +176,7 @@ describe('Check Answer and Hold Button', () => {
       expect(buttonAnswerHold.find('.buttonTitle').text()).toEqual('Answer & Hold');
 
       buttonAnswerHold.find(CircleButton).first().simulate('click');
-      await timeout(10);
+      await timeout(100);
       expect(phone.webphone.sessions).toHaveLength(2);
 
       await timeout(1000);
@@ -203,7 +202,7 @@ describe('Check Answer and Hold Button', () => {
       expect(buttonAnswerHold.find('.buttonTitle').text()).toEqual('Answer & Hold');
 
       buttonAnswerHold.find(CircleButton).first().simulate('click');
-      await timeout(10);
+      await timeout(100);
       expect(phone.webphone.sessions).toHaveLength(2);
 
       await timeout(1000);
@@ -232,7 +231,7 @@ describe('Check Answer and End Button', () => {
       expect(buttonAnswerEnd.find('.buttonTitle').text()).toEqual('Answer & End');
 
       buttonAnswerEnd.find(CircleButton).first().simulate('click');
-      await timeout(10);
+      await timeout(100);
       expect(phone.webphone.sessions).toHaveLength(1);
 
       await timeout(1000);
@@ -256,7 +255,7 @@ describe('Check Answer and End Button', () => {
       expect(buttonAnswerEnd.find('.buttonTitle').text()).toEqual('Answer & End');
 
       buttonAnswerEnd.find(CircleButton).first().simulate('click');
-      await timeout(10);
+      await timeout(100);
       expect(phone.webphone.sessions).toHaveLength(1);
 
       await timeout(1000);
@@ -280,7 +279,7 @@ describe('Check Ignore Button', () => {
     expect(buttonIgnore.find('.buttonTitle').text()).toEqual('Ignore');
 
     buttonIgnore.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     expect(phone.webphone.sessions).toHaveLength(0);
 
     wrapper.update();
@@ -298,7 +297,7 @@ describe('Check Ignore Button', () => {
     expect(buttonIgnore.find('.buttonTitle').text()).toEqual('Ignore');
 
     buttonIgnore.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     expect(phone.webphone.sessions).toHaveLength(1);
 
     wrapper.update();
@@ -319,7 +318,7 @@ describe('Check Ignore Button', () => {
       expect(buttonIgnore.find('.buttonTitle').text()).toEqual('Ignore');
 
       buttonIgnore.find(CircleButton).simulate('click');
-      await timeout(10);
+      await timeout(100);
       expect(phone.webphone.sessions).toHaveLength(1);
 
       wrapper.update();
@@ -339,7 +338,7 @@ describe('Check Incoming Call Forward Button', () => {
     expect(buttonForward.find('.buttonTitle').text()).toEqual('Forward');
 
     buttonForward.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
     expect(wrapper.find(Tooltip).at(0).props().visible).toBe(true);
     done();
@@ -352,7 +351,7 @@ describe('Check Incoming Call Forward Button', () => {
     expect(buttonForward.find('.buttonTitle').text()).toEqual('Forward');
 
     buttonForward.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
     expect(wrapper.find(Tooltip).at(0).props().visible).toBe(true);
     done();
@@ -365,7 +364,7 @@ describe('Check Incoming Call Forward Button', () => {
     expect(buttonForward.find('.buttonTitle').text()).toEqual('Forward');
 
     buttonForward.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
     expect(wrapper.find(Tooltip).at(0).props().visible).toBe(true);
     done();
@@ -378,13 +377,13 @@ describe('Check Incoming Call Forward Button > ForwardForm', () => {
     await makeInbountCall(phone, wrapper, sid111);
     const buttonForward = wrapper.find(IncomingCallPad).find(ActiveCallButton).at(0);
     buttonForward.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
 
     const domForwardForm = wrapper.find(ForwardForm);
     const btnCancel = domForwardForm.find(Button).at(0);
     btnCancel.simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
     expect(wrapper.find(Tooltip).at(0).props().visible).toBe(false);
     done();
@@ -394,14 +393,13 @@ describe('Check Incoming Call Forward Button > ForwardForm', () => {
     await makeInbountCall(phone, wrapper, sid111);
     const buttonForward = wrapper.find(IncomingCallPad).find(ActiveCallButton).at(0);
     buttonForward.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
 
     const domForwardForm = wrapper.find(ForwardForm);
     const btnForward = domForwardForm.find(Button).at(1);
     btnForward.simulate('click');
-    await timeout(10);
-    await timeout(200);
+    await timeout(100);
     wrapper.update();
     expect(forwardFn.mock.calls[0]).toContain('+16505819954');
     expect(phone.webphone.sessions).toHaveLength(0);
@@ -417,7 +415,7 @@ describe('Check Incoming Call Forward Button > ForwardForm', () => {
     await makeInbountCall(phone, wrapper, sid111);
     const buttonForward = wrapper.find(IncomingCallPad).find(ActiveCallButton).at(0);
     buttonForward.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
 
     const domForwardForm = wrapper.find(ForwardForm);
@@ -426,8 +424,7 @@ describe('Check Incoming Call Forward Button > ForwardForm', () => {
     const validatedResult = await phone.numberValidate.validateNumbers(['987654321']);
     const validPhoneNumber = validatedResult.numbers[0] && validatedResult.numbers[0].e164;
     btnForward.simulate('click');
-    await timeout(10);
-    await timeout(200);
+    await timeout(100);
     wrapper.update();
     expect(forwardFn.mock.calls[0]).toContain(validPhoneNumber);
     expect(phone.webphone.sessions).toHaveLength(0);
@@ -442,15 +439,14 @@ describe('Check Incoming Call Forward Button > ForwardForm', () => {
     await makeInbountCall(phone, wrapper, sid111);
     const buttonForward = wrapper.find(IncomingCallPad).find(ActiveCallButton).at(0);
     buttonForward.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
 
     const domForwardForm = wrapper.find(ForwardForm);
     const btnForward = domForwardForm.find(Button).at(1);
     await enterToNumber(domForwardForm, 'abcdefg');
     btnForward.simulate('click');
-    await timeout(10);
-    await timeout(200);
+    await timeout(100);
     const store = wrapper.props().phone.store;
     const messages = store.getState(wrapper).alert.messages;
     expect(messages).toEqual(
@@ -475,7 +471,7 @@ describe('Check Incoming Call Reply Button', () => {
     expect(buttonReply.find('.buttonTitle').text()).toEqual('Reply');
 
     buttonReply.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
     expect(wrapper.find(Tooltip).at(1).props().visible).toBe(true);
     done();
@@ -487,7 +483,7 @@ describe('Check Incoming Call Reply Button', () => {
     expect(buttonReply.find('.buttonTitle').text()).toEqual('Reply');
 
     buttonReply.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
     expect(wrapper.find(Tooltip).at(1).props().visible).toBe(true);
     done();
@@ -500,7 +496,7 @@ describe('Check Incoming Call Reply Button > ReplyWithMessage', () => {
     await makeInbountCall(phone, wrapper, sid111);
     const buttonReply = wrapper.find(IncomingCallPad).find(ActiveCallButton).at(1);
     buttonReply.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
 
     const domReplyWithMessage = wrapper.find(ReplyWithMessage);
@@ -519,13 +515,13 @@ describe('Check Incoming Call Reply Button > ReplyWithMessage', () => {
     await makeInbountCall(phone, wrapper, sid111);
     const buttonReply = wrapper.find(IncomingCallPad).find(ActiveCallButton).at(1);
     buttonReply.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
 
     const domReplyWithMessage = wrapper.find(ReplyWithMessage);
     const btnCancel = domReplyWithMessage.find(Button).at(0);
     btnCancel.first().simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
     expect(wrapper.find(Tooltip).at(1).props().visible).toBe(false);
     done();
@@ -536,22 +532,21 @@ describe('Check Incoming Call Reply Button > ReplyWithMessage', () => {
     await makeInbountCall(phone, wrapper, sid111);
     const buttonReply = wrapper.find(IncomingCallPad).find(ActiveCallButton).at(1);
     buttonReply.find(CircleButton).simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
 
     const domReplyWithMessage = wrapper.find(ReplyWithMessage);
     const domMessageItem = domReplyWithMessage.find('.messageItem').at(0);
     const btnReply = domReplyWithMessage.find(Button).at(1);
     domMessageItem.simulate('click');
-    await timeout(10);
-    await timeout(200);
+    await timeout(100);
     const replyText = '666888';
     enterToNumber(domMessageItem, replyText);
     await timeout(200);
     wrapper.update();
 
     btnReply.simulate('click');
-    await timeout(10);
+    await timeout(100);
     wrapper.update();
     expect(replyFn.mock.calls[0]).toEqual(
       expect.arrayContaining([

--- a/packages/ringcentral-widgets-test/test/integration-test/calls/Calls.spec.js
+++ b/packages/ringcentral-widgets-test/test/integration-test/calls/Calls.spec.js
@@ -70,7 +70,7 @@ describe('RCI-1038#4 All Calls Page', () => {
     expect(currentCallPanel.find('div.listTitle').text()).toEqual('Current Call');
     if (panel.props().useV2) {
       const buttons = currentCallPanel.find(ActiveCallItemV2).find('.webphoneButtons > span');
-      expect(buttons.at(0).props().title).toEqual('Unhold');
+      expect(buttons.at(0).props().title).toEqual('Hold');
       expect(buttons.at(1).props().title).toEqual('Hangup');
     } else {
       const buttons = currentCallPanel.find(ActiveCallItem).find('.webphoneButtons > span');

--- a/packages/ringcentral-widgets-test/test/integration-test/calls/helper.js
+++ b/packages/ringcentral-widgets-test/test/integration-test/calls/helper.js
@@ -15,7 +15,7 @@ import {
 } from '../../support/callHelper';
 
 function mockCallProcedure(func) {
-  return async function (phone, ...args) {
+  return async (phone, ...args) => {
     mock.device(deviceBody, false);
     const activeCallsBody = await func.apply(null, [phone, ...args]);
     mock.activeCalls(activeCallsBody);
@@ -89,10 +89,8 @@ export async function mockMultiOutboundCalls(phone, n) {
 }
 // all calls page
 export async function makeInboudCalls(phone, optional = []) {
-  const inboundSessions = [];
   for (const option of optional) {
-    const inboundSession = await getInboundCall(phone, option);
-    inboundSessions.push(inboundSession);
+    await getInboundCall(phone, option);
   }
   const activeCallBody = await mockActiveCalls(phone.webphone.sessions);
   mock.activeCalls(activeCallBody);

--- a/packages/ringcentral-widgets-test/test/support/callHelper.js
+++ b/packages/ringcentral-widgets-test/test/support/callHelper.js
@@ -38,9 +38,9 @@ export async function getInboundCall(phone, options = defaultInboundOption) {
 
 export async function makeCall(phone, options = defaultOutboundOption) {
   mock.device(deviceBody);
-  phone.webphone.sessions.forEach(async (session) => {
+  for (const session of phone.webphone.sessions) {
     await phone.webphone.hold(session.id);
-  });
+  }
   const session = await phone.webphone.makeCall(options);
   session.__rc_callId = `call-${session.id}`;
   return session;

--- a/packages/ringcentral-widgets-test/test/support/callHelper.js
+++ b/packages/ringcentral-widgets-test/test/support/callHelper.js
@@ -15,14 +15,12 @@ const defaultInboundOption = {
 };
 
 const defaultOutboundOption = {
-  callId: true,
   fromNumber: '+15878133670',
   homeCountryId: '1',
   toNumber: '101',
 };
 
 const defaultConferenceOption = {
-  callId: true,
   fromNumber: '+15878133670',
   homeCountryId: '1',
   toNumber: 'conf_7777777777777777',
@@ -30,27 +28,27 @@ const defaultConferenceOption = {
 };
 
 export async function getInboundCall(phone, options = defaultInboundOption) {
-  phone.webphone.sessions.forEach(session => phone.webphone.hold(session.id));
-  const session = new Session(options);
+  const session = new Session({
+    ...options,
+    callId: options.callId || `call-${options.id}`
+  });
   await phone.webphone._webphone.userAgent.trigger('invite', session);
   return session;
 }
 
 export async function makeCall(phone, options = defaultOutboundOption) {
   mock.device(deviceBody);
-  phone.webphone.sessions.forEach(session => phone.webphone.hold(session.id));
+  phone.webphone.sessions.forEach(async (session) => {
+    await phone.webphone.hold(session.id);
+  });
   const session = await phone.webphone.makeCall(options);
-  if (options.callId) {
-    session.__rc_callId = `call-${session.id}`;
-  }
+  session.__rc_callId = `call-${session.id}`;
   return session;
 }
 
 export async function makeConferenceCall(phone, options = defaultConferenceOption) {
   const session = await phone.webphone.makeCall(options);
-  if (options.callId) {
-    session.__rc_callId = `call-${session.id}`;
-  }
+  session.__rc_callId = `call-${session.id}`;
   return session;
 }
 

--- a/packages/ringcentral-widgets-test/test/support/session.js
+++ b/packages/ringcentral-widgets-test/test/support/session.js
@@ -92,7 +92,9 @@ export default class Session {
   }
 
   trigger(event, ...args) {
-    this._events[event](...args);
+    if (typeof this._events[event] === 'function') {
+      this._events[event](...args);
+    }
   }
 
   // Change Session Id
@@ -134,8 +136,8 @@ export default class Session {
     return unmuteFn(this.id);
   }
 
-  hold() {
-    this.trigger('hold');
+  async hold() {
+    await this.trigger('hold');
     this.__rc_callStatus = sessionStatus.onHold;
     return holdFn(this.id);
   }


### PR DESCRIPTION
1. getInboundCall function
    Inbound Call/Incoming Call Session do not have callId

2. when it comes to execute "phone.webphone.hold"
    it is an asynchronous function, need to add await

3. add timeout after simulate action for flow.spec.js IncomingCallPad.spec.js