### PR TITLE
hide call control overlap components on call changed

### DIFF
--- a/packages/ringcentral-widgets/components/CallCtrlPanel/index.js
+++ b/packages/ringcentral-widgets/components/CallCtrlPanel/index.js
@@ -43,9 +43,16 @@ class CallCtrlPanel extends Component {
 
     this.toggleTransferPanel = () => {
       this.setState(prevState => ({
-        isShowTransferPanel: !prevState.isShowTransferPanel
+        isShowTransferPanel: !prevState.isShowTransferPanel,
       }));
     };
+
+    this.hideTransferPanel = () => {
+      this.setState({
+        isShowTransferPanel: false,
+      });
+    };
+
     this.onMerge = () => {
       const { onBeforeMerge } = this.props;
       if (!onBeforeMerge || onBeforeMerge()) {
@@ -69,8 +76,12 @@ class CallCtrlPanel extends Component {
 
     this.hideMergeConfirm = () => {
       this.setState({
-        isShowMergeConfirm: false
+        isShowMergeConfirm: false,
       });
+    };
+
+    this.hideMergeConfirmAlt = () => {
+      this.hideMergeConfirm();
       // user action track
       this.props.afterHideMergeConfirm();
     };
@@ -93,9 +104,13 @@ class CallCtrlPanel extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (!nextProps.hasConferenceCall && this.state.isShowMergeConfirm) {
-      this.setState({
-        isShowMergeConfirm: false
-      });
+      this.hideMergeConfirm();
+    }
+    if (this.props.sessionId !== nextProps.sessionId) {
+      this.hiddenKeyPad();
+      this.hideFlipPanel();
+      this.hideTransferPanel();
+      this.hideMergeConfirm();
     }
   }
 
@@ -196,7 +211,7 @@ class CallCtrlPanel extends Component {
             currentLocale={this.props.currentLocale}
             show={this.state.isShowMergeConfirm}
             onMerge={this.confirmMerge}
-            onCancel={this.hideMergeConfirm}
+            onCancel={this.hideMergeConfirmAlt}
             partyProfiles={this.props.conferenceCallParties}
           />
           : null


### PR DESCRIPTION
hide call control overlap components (KeypadPanel/FlipPanel/TransferPanel/MergeConfirm) on call changed