### PR TITLE
fix(TabNavigationView): TabNavigationView DropdownMenu z-index update

### DIFF
--- a/packages/ringcentral-widgets/components/DropdownNavigationView/styles.scss
+++ b/packages/ringcentral-widgets/components/DropdownNavigationView/styles.scss
@@ -4,6 +4,5 @@
   padding: 7px 0;
   background-color: #ffffff;
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.15);
-  box-shadow: 0 2px 5px 0 #cccccc;
   z-index: 11;
 }

--- a/packages/ringcentral-widgets/components/TabNavigationView/index.js
+++ b/packages/ringcentral-widgets/components/TabNavigationView/index.js
@@ -21,11 +21,13 @@ function TabNavigationView(props) {
   if (props.holdReady) return null;
   return (
     <div className={classnames(styles.root, props.className)} >
-      {
-        props.navigationPosition === 'top' ?
-          navBar :
-          null
-      }
+      <div className={styles.tabContainer}>
+        {
+          props.navigationPosition === 'top' ?
+            navBar :
+            null
+        }
+      </div>
       <div className={styles.main}>
         {props.children}
       </div>

--- a/packages/ringcentral-widgets/components/TabNavigationView/styles.scss
+++ b/packages/ringcentral-widgets/components/TabNavigationView/styles.scss
@@ -4,7 +4,11 @@
 .root {
   @include full-size;
 }
+.tabContainer {
+  z-index: 11;
+}
 .main {
   @include full-size;
   max-height: calc(100% - #{$navigation-bar-height});
+  z-index: 10;
 }


### PR DESCRIPTION
The dropdown menu of TabNavigationView should not be blocked by tab content's SpinnerOverlay.