### PR TITLE
refactor(ContactDetails, AccountContacts): using PhoneTypes.js & PhoneTypeNames.js

### DIFF
--- a/packages/ringcentral-integration/enums/phoneTypes.js
+++ b/packages/ringcentral-integration/enums/phoneTypes.js
@@ -1,6 +1,5 @@
-import Enum from 'ringcentral-integration/lib/Enum';
+import Enum from '../lib/Enum';
 
-// FIXME: delete this after syncing up
 export default new Enum([
   'business',
   'extension',

--- a/packages/ringcentral-integration/modules/AccountContacts/index.js
+++ b/packages/ringcentral-integration/modules/AccountContacts/index.js
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 import { reduce } from 'ramda';
+import phoneTypes from '../../enums/phoneTypes';
 import RcModule from '../../lib/RcModule';
 import { Module } from '../../lib/di';
 import isBlank from '../../lib/isBlank';
@@ -276,7 +277,7 @@ export default class AccountContacts extends RcModule {
           emails: extension.contact ? [extension.contact.email] : [],
           extensionNumber: extension.ext,
           hasProfileImage: !!extension.hasProfileImage,
-          phoneNumbers: [{ phoneNumber: extension.ext, phoneType: 'extension' }],
+          phoneNumbers: [{ phoneNumber: extension.ext, phoneType: phoneTypes.extension }],
           profileImageUrl: profileImages[id] && profileImages[id].imageUrl,
           presence: presences[id] && presences[id].presence,
           contactStatus: extension.status,
@@ -288,7 +289,7 @@ export default class AccountContacts extends RcModule {
         const phones = extensionToPhoneNumberMap[contact.extensionNumber];
         if (phones && phones.length > 0) {
           phones.forEach((phone) => {
-            addPhoneToContact(contact, phone.phoneNumber, 'directPhone');
+            addPhoneToContact(contact, phone.phoneNumber, phoneTypes.direct);
           });
         }
         result.push(contact);

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/de-DE.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/de-DE.js
@@ -3,8 +3,6 @@ import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
 import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  [phoneTypes.extension]: "Durchw.",
-  [phoneTypes.direct]: "Direkt",
   emailLabel: "E-Mail",
   call: "Anrufen",
   text: "Textnachr",
@@ -15,8 +13,6 @@ export default {
   notActivated: "Inaktiv"
 };
 
-// @key: @#@"extensionLabel"@#@ @source: @#@"Ext."@#@
-// @key: @#@"directLabel"@#@ @source: @#@"Direct"@#@
 // @key: @#@"emailLabel"@#@ @source: @#@"Email"@#@
 // @key: @#@"call"@#@ @source: @#@"Call"@#@
 // @key: @#@"text"@#@ @source: @#@"Text"@#@

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/de-DE.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/de-DE.js
@@ -1,9 +1,10 @@
 import presenceStatus from 'ringcentral-integration/modules/Presence/presenceStatus';
 import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
+import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  extensionLabel: "Durchw.",
-  directLabel: "Direkt",
+  [phoneTypes.extension]: "Durchw.",
+  [phoneTypes.direct]: "Direkt",
   emailLabel: "E-Mail",
   call: "Anrufen",
   text: "Textnachr",

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/en-AU.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/en-AU.js
@@ -3,8 +3,6 @@ import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
 import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  [phoneTypes.extension]: "Ext.",
-  [phoneTypes.direct]: "Direct",
   emailLabel: "Email",
   call: "Call",
   text: "Text",
@@ -15,8 +13,6 @@ export default {
   notActivated: "Inactive"
 };
 
-// @key: @#@"extensionLabel"@#@ @source: @#@"Ext."@#@
-// @key: @#@"directLabel"@#@ @source: @#@"Direct"@#@
 // @key: @#@"emailLabel"@#@ @source: @#@"Email"@#@
 // @key: @#@"call"@#@ @source: @#@"Call"@#@
 // @key: @#@"text"@#@ @source: @#@"Text"@#@

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/en-AU.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/en-AU.js
@@ -1,9 +1,10 @@
 import presenceStatus from 'ringcentral-integration/modules/Presence/presenceStatus';
 import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
+import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  extensionLabel: "Ext.",
-  directLabel: "Direct",
+  [phoneTypes.extension]: "Ext.",
+  [phoneTypes.direct]: "Direct",
   emailLabel: "Email",
   call: "Call",
   text: "Text",

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/en-CA.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/en-CA.js
@@ -3,8 +3,6 @@ import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
 import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  [phoneTypes.extension]: "Ext.",
-  [phoneTypes.direct]: "Direct",
   emailLabel: "Email",
   call: "Call",
   text: "Text",
@@ -15,8 +13,6 @@ export default {
   notActivated: "Inactive"
 };
 
-// @key: @#@"extensionLabel"@#@ @source: @#@"Ext."@#@
-// @key: @#@"directLabel"@#@ @source: @#@"Direct"@#@
 // @key: @#@"emailLabel"@#@ @source: @#@"Email"@#@
 // @key: @#@"call"@#@ @source: @#@"Call"@#@
 // @key: @#@"text"@#@ @source: @#@"Text"@#@

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/en-CA.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/en-CA.js
@@ -1,9 +1,10 @@
 import presenceStatus from 'ringcentral-integration/modules/Presence/presenceStatus';
 import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
+import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  extensionLabel: "Ext.",
-  directLabel: "Direct",
+  [phoneTypes.extension]: "Ext.",
+  [phoneTypes.direct]: "Direct",
   emailLabel: "Email",
   call: "Call",
   text: "Text",

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/en-GB.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/en-GB.js
@@ -3,8 +3,6 @@ import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
 import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  [phoneTypes.extension]: "Ext.",
-  [phoneTypes.direct]: "Direct",
   emailLabel: "Email",
   call: "Call",
   text: "Text",
@@ -15,8 +13,6 @@ export default {
   notActivated: "Inactive"
 };
 
-// @key: @#@"extensionLabel"@#@ @source: @#@"Ext."@#@
-// @key: @#@"directLabel"@#@ @source: @#@"Direct"@#@
 // @key: @#@"emailLabel"@#@ @source: @#@"Email"@#@
 // @key: @#@"call"@#@ @source: @#@"Call"@#@
 // @key: @#@"text"@#@ @source: @#@"Text"@#@

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/en-GB.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/en-GB.js
@@ -1,9 +1,10 @@
 import presenceStatus from 'ringcentral-integration/modules/Presence/presenceStatus';
 import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
+import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  extensionLabel: "Ext.",
-  directLabel: "Direct",
+  [phoneTypes.extension]: "Ext.",
+  [phoneTypes.direct]: "Direct",
   emailLabel: "Email",
   call: "Call",
   text: "Text",

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/en-US.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/en-US.js
@@ -8,7 +8,7 @@ export default {
   [phoneTypes.mobile]: 'Mobile',
   [phoneTypes.home]: 'Home',
   [phoneTypes.business]: 'Business',
-  [phoneTypes.fax]: 'fax',
+  [phoneTypes.fax]: 'Fax',
   emailLabel: 'Email',
   call: 'Call',
   text: 'Text',

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/en-US.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/en-US.js
@@ -1,9 +1,14 @@
 import presenceStatus from 'ringcentral-integration/modules/Presence/presenceStatus';
 import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
+import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  extensionLabel: 'Ext.',
-  directLabel: 'Direct',
+  [phoneTypes.extension]: 'Ext.',
+  [phoneTypes.direct]: 'Direct',
+  [phoneTypes.mobile]: 'Mobile',
+  [phoneTypes.home]: 'Home',
+  [phoneTypes.business]: 'Business',
+  [phoneTypes.fax]: 'fax',
   emailLabel: 'Email',
   call: 'Call',
   text: 'Text',

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/es-419.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/es-419.js
@@ -1,9 +1,10 @@
 import presenceStatus from 'ringcentral-integration/modules/Presence/presenceStatus';
 import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
+import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  extensionLabel: "Ext.",
-  directLabel: "Directo",
+  [phoneTypes.extension]: "Ext.",
+  [phoneTypes.direct]: "Directo",
   emailLabel: "Correo electrónico",
   call: "Llamar",
   text: "Texto",

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/es-419.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/es-419.js
@@ -3,8 +3,6 @@ import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
 import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  [phoneTypes.extension]: "Ext.",
-  [phoneTypes.direct]: "Directo",
   emailLabel: "Correo electrónico",
   call: "Llamar",
   text: "Texto",
@@ -15,8 +13,6 @@ export default {
   notActivated: "Inactivo"
 };
 
-// @key: @#@"extensionLabel"@#@ @source: @#@"Ext."@#@
-// @key: @#@"directLabel"@#@ @source: @#@"Direct"@#@
 // @key: @#@"emailLabel"@#@ @source: @#@"Email"@#@
 // @key: @#@"call"@#@ @source: @#@"Call"@#@
 // @key: @#@"text"@#@ @source: @#@"Text"@#@

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/es-ES.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/es-ES.js
@@ -1,9 +1,10 @@
 import presenceStatus from 'ringcentral-integration/modules/Presence/presenceStatus';
 import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
+import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  extensionLabel: "Ext.",
-  directLabel: "Directo",
+  [phoneTypes.extension]: "Ext.",
+  [phoneTypes.direct]: "Directo",
   emailLabel: "Correo electrónico",
   call: "Llamar",
   text: "Texto",

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/es-ES.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/es-ES.js
@@ -3,8 +3,6 @@ import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
 import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  [phoneTypes.extension]: "Ext.",
-  [phoneTypes.direct]: "Directo",
   emailLabel: "Correo electrónico",
   call: "Llamar",
   text: "Texto",
@@ -15,8 +13,6 @@ export default {
   notActivated: "Inactivo"
 };
 
-// @key: @#@"extensionLabel"@#@ @source: @#@"Ext."@#@
-// @key: @#@"directLabel"@#@ @source: @#@"Direct"@#@
 // @key: @#@"emailLabel"@#@ @source: @#@"Email"@#@
 // @key: @#@"call"@#@ @source: @#@"Call"@#@
 // @key: @#@"text"@#@ @source: @#@"Text"@#@

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/fr-CA.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/fr-CA.js
@@ -1,9 +1,10 @@
 import presenceStatus from 'ringcentral-integration/modules/Presence/presenceStatus';
 import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
+import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  extensionLabel: "Poste",
-  directLabel: "Direct",
+  [phoneTypes.extension]: "Poste",
+  [phoneTypes.direct]: "Direct",
   emailLabel: "Courriel",
   call: "Appeler",
   text: "Texto",

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/fr-CA.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/fr-CA.js
@@ -3,8 +3,6 @@ import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
 import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  [phoneTypes.extension]: "Poste",
-  [phoneTypes.direct]: "Direct",
   emailLabel: "Courriel",
   call: "Appeler",
   text: "Texto",
@@ -15,8 +13,6 @@ export default {
   notActivated: "Inactif"
 };
 
-// @key: @#@"extensionLabel"@#@ @source: @#@"Ext."@#@
-// @key: @#@"directLabel"@#@ @source: @#@"Direct"@#@
 // @key: @#@"emailLabel"@#@ @source: @#@"Email"@#@
 // @key: @#@"call"@#@ @source: @#@"Call"@#@
 // @key: @#@"text"@#@ @source: @#@"Text"@#@

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/fr-FR.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/fr-FR.js
@@ -3,8 +3,6 @@ import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
 import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  [phoneTypes.extension]: "Ext.",
-  [phoneTypes.direct]: "Direct",
   emailLabel: "E-mail",
   call: "Appeler",
   text: "Texte",
@@ -15,8 +13,6 @@ export default {
   notActivated: "Inactif"
 };
 
-// @key: @#@"extensionLabel"@#@ @source: @#@"Ext."@#@
-// @key: @#@"directLabel"@#@ @source: @#@"Direct"@#@
 // @key: @#@"emailLabel"@#@ @source: @#@"Email"@#@
 // @key: @#@"call"@#@ @source: @#@"Call"@#@
 // @key: @#@"text"@#@ @source: @#@"Text"@#@

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/fr-FR.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/fr-FR.js
@@ -1,9 +1,10 @@
 import presenceStatus from 'ringcentral-integration/modules/Presence/presenceStatus';
 import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
+import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  extensionLabel: "Ext.",
-  directLabel: "Direct",
+  [phoneTypes.extension]: "Ext.",
+  [phoneTypes.direct]: "Direct",
   emailLabel: "E-mail",
   call: "Appeler",
   text: "Texte",

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/it-IT.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/it-IT.js
@@ -1,9 +1,10 @@
 import presenceStatus from 'ringcentral-integration/modules/Presence/presenceStatus';
 import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
+import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  extensionLabel: "Int.",
-  directLabel: "Diretto",
+  [phoneTypes.extension]: "Int.",
+  [phoneTypes.direct]: "Diretto",
   emailLabel: "E-mail",
   call: "Chiamata",
   text: "SMS",

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/it-IT.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/it-IT.js
@@ -3,8 +3,6 @@ import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
 import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  [phoneTypes.extension]: "Int.",
-  [phoneTypes.direct]: "Diretto",
   emailLabel: "E-mail",
   call: "Chiamata",
   text: "SMS",
@@ -15,8 +13,6 @@ export default {
   notActivated: "Inattivo"
 };
 
-// @key: @#@"extensionLabel"@#@ @source: @#@"Ext."@#@
-// @key: @#@"directLabel"@#@ @source: @#@"Direct"@#@
 // @key: @#@"emailLabel"@#@ @source: @#@"Email"@#@
 // @key: @#@"call"@#@ @source: @#@"Call"@#@
 // @key: @#@"text"@#@ @source: @#@"Text"@#@

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/ja-JP.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/ja-JP.js
@@ -3,8 +3,6 @@ import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
 import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  [phoneTypes.extension]: "内線",
-  [phoneTypes.direct]: "ダイレクト",
   emailLabel: "Eメール",
   call: "通話",
   text: "テキスト",
@@ -15,8 +13,6 @@ export default {
   notActivated: "非アクティブ"
 };
 
-// @key: @#@"extensionLabel"@#@ @source: @#@"Ext."@#@
-// @key: @#@"directLabel"@#@ @source: @#@"Direct"@#@
 // @key: @#@"emailLabel"@#@ @source: @#@"Email"@#@
 // @key: @#@"call"@#@ @source: @#@"Call"@#@
 // @key: @#@"text"@#@ @source: @#@"Text"@#@

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/ja-JP.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/ja-JP.js
@@ -1,9 +1,10 @@
 import presenceStatus from 'ringcentral-integration/modules/Presence/presenceStatus';
 import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
+import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  extensionLabel: "内線",
-  directLabel: "ダイレクト",
+  [phoneTypes.extension]: "内線",
+  [phoneTypes.direct]: "ダイレクト",
   emailLabel: "Eメール",
   call: "通話",
   text: "テキスト",

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/pt-BR.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/pt-BR.js
@@ -3,8 +3,6 @@ import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
 import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  [phoneTypes.extension]: "Ramal",
-  [phoneTypes.direct]: "Direto",
   emailLabel: "Email",
   call: "Chamada",
   text: "Texto",
@@ -15,8 +13,6 @@ export default {
   notActivated: "Inativo"
 };
 
-// @key: @#@"extensionLabel"@#@ @source: @#@"Ext."@#@
-// @key: @#@"directLabel"@#@ @source: @#@"Direct"@#@
 // @key: @#@"emailLabel"@#@ @source: @#@"Email"@#@
 // @key: @#@"call"@#@ @source: @#@"Call"@#@
 // @key: @#@"text"@#@ @source: @#@"Text"@#@

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/pt-BR.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/pt-BR.js
@@ -1,9 +1,10 @@
 import presenceStatus from 'ringcentral-integration/modules/Presence/presenceStatus';
 import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
+import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  extensionLabel: "Ramal",
-  directLabel: "Direto",
+  [phoneTypes.extension]: "Ramal",
+  [phoneTypes.direct]: "Direto",
   emailLabel: "Email",
   call: "Chamada",
   text: "Texto",

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/zh-CN.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/zh-CN.js
@@ -1,9 +1,10 @@
 import presenceStatus from 'ringcentral-integration/modules/Presence/presenceStatus';
 import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
+import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  extensionLabel: "分机",
-  directLabel: "直拨",
+  [phoneTypes.extension]: "分机",
+  [phoneTypes.direct]: "直拨",
   emailLabel: "电子邮件",
   call: "呼叫",
   text: "短信",

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/zh-CN.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/zh-CN.js
@@ -3,8 +3,6 @@ import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
 import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  [phoneTypes.extension]: "分机",
-  [phoneTypes.direct]: "直拨",
   emailLabel: "电子邮件",
   call: "呼叫",
   text: "短信",
@@ -15,8 +13,6 @@ export default {
   notActivated: "停用"
 };
 
-// @key: @#@"extensionLabel"@#@ @source: @#@"Ext."@#@
-// @key: @#@"directLabel"@#@ @source: @#@"Direct"@#@
 // @key: @#@"emailLabel"@#@ @source: @#@"Email"@#@
 // @key: @#@"call"@#@ @source: @#@"Call"@#@
 // @key: @#@"text"@#@ @source: @#@"Text"@#@

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/zh-HK.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/zh-HK.js
@@ -1,17 +1,18 @@
 import presenceStatus from 'ringcentral-integration/modules/Presence/presenceStatus';
 import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
+import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  extensionLabel: "分機",
-  directLabel: "通訊錄",
-  emailLabel: "電子郵件",
-  call: "通話",
-  text: "簡訊",
-  [presenceStatus.available]: "可用",
-  [presenceStatus.offline]: "隱形",
-  [presenceStatus.busy]: "忙碌",
-  [dndStatus.doNotAcceptAnyCalls]: "勿打擾",
-  notActivated: "非使用中"
+  [phoneTypes.extension]: '分機',
+  [phoneTypes.direct]: '通訊錄',
+  emailLabel: '電子郵件',
+  call: '通話',
+  text: '簡訊',
+  [presenceStatus.available]: '可用',
+  [presenceStatus.offline]: '隱形',
+  [presenceStatus.busy]: '忙碌',
+  [dndStatus.doNotAcceptAnyCalls]: '勿打擾',
+  notActivated: '非使用中'
 };
 
 // @key: @#@"extensionLabel"@#@ @source: @#@"Ext."@#@

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/zh-HK.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/zh-HK.js
@@ -3,8 +3,6 @@ import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
 import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  [phoneTypes.extension]: '分機',
-  [phoneTypes.direct]: '通訊錄',
   emailLabel: '電子郵件',
   call: '通話',
   text: '簡訊',
@@ -15,8 +13,6 @@ export default {
   notActivated: '非使用中'
 };
 
-// @key: @#@"extensionLabel"@#@ @source: @#@"Ext."@#@
-// @key: @#@"directLabel"@#@ @source: @#@"Direct"@#@
 // @key: @#@"emailLabel"@#@ @source: @#@"Email"@#@
 // @key: @#@"call"@#@ @source: @#@"Call"@#@
 // @key: @#@"text"@#@ @source: @#@"Text"@#@

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/zh-TW.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/zh-TW.js
@@ -3,8 +3,6 @@ import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
 import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  [phoneTypes.extension]: "分機",
-  [phoneTypes.direct]: "通訊錄",
   emailLabel: "電子郵件",
   call: "通話",
   text: "簡訊",
@@ -15,8 +13,6 @@ export default {
   notActivated: "非使用中"
 };
 
-// @key: @#@"extensionLabel"@#@ @source: @#@"Ext."@#@
-// @key: @#@"directLabel"@#@ @source: @#@"Direct"@#@
 // @key: @#@"emailLabel"@#@ @source: @#@"Email"@#@
 // @key: @#@"call"@#@ @source: @#@"Call"@#@
 // @key: @#@"text"@#@ @source: @#@"Text"@#@

--- a/packages/ringcentral-widgets/components/ContactDetails/i18n/zh-TW.js
+++ b/packages/ringcentral-widgets/components/ContactDetails/i18n/zh-TW.js
@@ -1,9 +1,10 @@
 import presenceStatus from 'ringcentral-integration/modules/Presence/presenceStatus';
 import dndStatus from 'ringcentral-integration/modules/Presence/dndStatus';
+import phoneTypes from '../../../enums/phoneTypes';
 
 export default {
-  extensionLabel: "分機",
-  directLabel: "通訊錄",
+  [phoneTypes.extension]: "分機",
+  [phoneTypes.direct]: "通訊錄",
   emailLabel: "電子郵件",
   call: "通話",
   text: "簡訊",

--- a/packages/ringcentral-widgets/lib/phoneTypeNames/en-US.js
+++ b/packages/ringcentral-widgets/lib/phoneTypeNames/en-US.js
@@ -9,4 +9,6 @@ export default {
   [phoneTypes.unknown]: 'Unknown Phone Type',
   [phoneTypes.company]: 'Company Number',
   [phoneTypes.direct]: 'Direct Number',
+  [phoneTypes.fax]: 'Fax',
+  [phoneTypes.other]: 'Other',
 };


### PR DESCRIPTION
* remove hard coding direct lable on contact detail page
* repalce AccountContacts with phoneTypes
* add more phone type to ContactDetails.js

BREAKING CHANGE: Show all the phones with corresponding type name on contact detail page