### PR TITLE
fix(Conversations): fix conversations list load next page logic

### DIFF
--- a/packages/ringcentral-integration/modules/Conversations/getReducer.js
+++ b/packages/ringcentral-integration/modules/Conversations/getReducer.js
@@ -67,11 +67,12 @@ export function getFetchConversationsStatusReducer(types) {
 }
 
 export function getCurrentPageReducer(types) {
-  return (state = 1, { type }) => {
+  return (state = 1, { type, isIncreaseCurrentPage }) => {
     switch (type) {
       case types.increaseCurrentPage:
-      case types.fetchOldConverstaionsSuccess:
         return state + 1;
+      case types.fetchOldConverstaionsSuccess:
+        return isIncreaseCurrentPage ? state + 1 : state;
       case types.updateTypeFilter:
       case types.resetSuccess:
       case types.initSuccess:

--- a/packages/ringcentral-integration/modules/Conversations/getReducer.test.js
+++ b/packages/ringcentral-integration/modules/Conversations/getReducer.test.js
@@ -12,6 +12,8 @@ import getReducer, {
   getFetchMessagesStatusReducer,
   getMessageTextsReducer,
   getConversationStatusReducer,
+  getCorrespondentMatch,
+  getCorrespondentResponse,
 } from './getReducer';
 
 import actionTypes from './actionTypes';
@@ -216,15 +218,26 @@ describe('Conversations :: getCurrentPageReducer', () => {
       expect(reducer(originalState, { type: 'foo' }))
         .to.equal(originalState);
     });
-    it('should increase page on increaseCurrentPage or fetchOldConverstaionsSuccess', () => {
+    it('should increase page on increaseCurrentPage', () => {
       [
         actionTypes.increaseCurrentPage,
-        actionTypes.fetchOldConverstaionsSuccess,
       ].forEach((type) => {
         expect(reducer(2, {
           type,
         })).to.equal(3);
       });
+    });
+    it('should increase page when isIncreaseCurrentPage parameter is true when fetchOldConverstaionsSuccess', () => {
+      expect(reducer(2, {
+        type: actionTypes.fetchOldConverstaionsSuccess,
+        isIncreaseCurrentPage: true,
+      })).to.equal(3);
+    });
+    it('should not increase page when isIncreaseCurrentPage parameter is false when fetchOldConverstaionsSuccess', () => {
+      expect(reducer(2, {
+        type: actionTypes.fetchOldConverstaionsSuccess,
+        isIncreaseCurrentPage: false,
+      })).to.equal(2);
     });
     it('should return idle on resetSuccess', () => {
       [
@@ -480,6 +493,8 @@ describe('getReducer', () => {
     const fetchMessagesStatusReducer = getFetchMessagesStatusReducer(actionTypes);
     const messageTextsReducer = getMessageTextsReducer(actionTypes);
     const conversationStatusReducer = getConversationStatusReducer(actionTypes);
+    const correspondentMatchReducer = getCorrespondentMatch(actionTypes);
+    const correspondentResponseReducer = getCorrespondentResponse(actionTypes);
 
     it('should return the combined initialState', () => {
       expect(reducer(undefined, {})).to.deep.equal({
@@ -494,6 +509,8 @@ describe('getReducer', () => {
         fetchMessagesStatus: fetchMessagesStatusReducer(undefined, {}),
         messageTexts: messageTextsReducer(undefined, {}),
         conversationStatus: conversationStatusReducer(undefined, {}),
+        correspondentMatch: correspondentMatchReducer(undefined, {}),
+        correspondentResponse: correspondentResponseReducer(undefined, {}),
       });
     });
   });

--- a/packages/ringcentral-integration/modules/Conversations/index.js
+++ b/packages/ringcentral-integration/modules/Conversations/index.js
@@ -293,11 +293,15 @@ export default class Conversations extends RcModule {
         .extension()
         .messageStore()
         .list(params);
-      this._olderDataExsited = records.length === this._perPage;
+      const recordsLength = records.length;
+      this._olderDataExsited = recordsLength === this._perPage;
       if (typeFilter === this.typeFilter && currentPage === this.currentPage) {
+        const isIncreaseCurrentPage = recordsLength &&
+          (this._perPage * this.currentPage < recordsLength + this.filteredConversations.length);
         this.store.dispatch({
           type: this.actionTypes.fetchOldConverstaionsSuccess,
           records,
+          isIncreaseCurrentPage,
         });
       }
     } catch (e) {
@@ -312,7 +316,7 @@ export default class Conversations extends RcModule {
   @proxify
   async loadNextPage() {
     const currentPage = this.currentPage;
-    if ((currentPage + 1) * this._perPage <= this.filteredConversations.length) {
+    if (currentPage * this._perPage < this.filteredConversations.length) {
       this.store.dispatch({
         type: this.actionTypes.increaseCurrentPage,
       });


### PR DESCRIPTION
when loading next page, if filteredConversations'length is longer than displayable list'length should increase the current page.

And add a condition to judge whether it is necessary to increase the current page after fetching old conversations success.

fix #9068