### PR TITLE
fix(Fix:View for 0-calls not show):

### DIFF
--- a/packages/ringcentral-widgets/components/CallListV2/index.js
+++ b/packages/ringcentral-widgets/components/CallListV2/index.js
@@ -159,6 +159,16 @@ export default class CallListV2 extends React.PureComponent {
     );
   };
 
+  noRowsRender = () => {
+    const {
+      currentLocale,
+      active
+    } = this.props;
+    return (
+      <NoCalls currentLocale={currentLocale} active={active} />
+    );
+  }
+
   render() {
     const {
       width,
@@ -179,6 +189,7 @@ export default class CallListV2 extends React.PureComponent {
           rowCount={calls.length}
           rowHeight={this._renderRowHeight}
           rowRenderer={this._rowRender}
+          noRowsRenderer={this.noRowsRender}
       />
       </div>
     );


### PR DESCRIPTION
When there are no calls, related view did not show up. Fixed this problem by adding `noRowsRender` property for `List` in react-virtualized.