### PR TITLE
fix(CallListV2): call history multiple match popup clipped

### DIFF
--- a/packages/ringcentral-widgets/components/CallListV2/index.js
+++ b/packages/ringcentral-widgets/components/CallListV2/index.js
@@ -181,6 +181,7 @@ export default class CallListV2 extends React.PureComponent {
       <div>
         <List
           style={{ outline: 'none' }}
+          containerStyle={{ overflow: 'visible' }}
           ref={this._list}
           width={width}
           height={height}
@@ -190,7 +191,7 @@ export default class CallListV2 extends React.PureComponent {
           rowHeight={this._renderRowHeight}
           rowRenderer={this._rowRender}
           noRowsRenderer={this.noRowsRender}
-      />
+        />
       </div>
     );
   }


### PR DESCRIPTION
Fixed issue : https://jira.ringcentral.com/browse/RCINT-9288

When one of the call history items has multiple match, the popup will be clipped if sum of call history items' height is less than the List's.

There's a `Container` in *react-virtualized* `List` component. Set overflow to visible in the container everything works fine.